### PR TITLE
refs #21 Remove --id-param injection bug and fix id_param_name passthrough

### DIFF
--- a/.claude/skills/mcp-async-skill/scripts/generate_skill.py
+++ b/.claude/skills/mcp-async-skill/scripts/generate_skill.py
@@ -375,7 +375,6 @@ def convert_tools_to_yaml_dict(tools: list[dict], mcp_config: dict = None, skill
                 "--poll-interval": "ポーリング間隔秒数 (デフォルト: 2.0)",
                 "--max-polls": "最大ポーリング回数 (デフォルト: 300)",
                 "--header": "カスタムヘッダー追加 (Key:Value形式、複数可)",
-                "--id-param": "ジョブIDパラメータ名 (デフォルト: request_id)",
                 "--save-logs": "{output}/logs/ にログ保存",
                 "--save-logs-inline": "出力ファイル横にログ保存",
                 "--queue-config": "queue_config.jsonへのパス（キューモード有効化）",
@@ -761,7 +760,6 @@ python .claude/skills/{skill_name}/scripts/mcp_async_call.py \\
 | `--poll-interval` | - | ポーリング間隔 (秒) | `2.0` |
 | `--max-polls` | - | 最大ポーリング回数 | `300` |
 | `--header` | - | カスタムヘッダー追加 (`Key:Value`形式、複数可) | - |
-| `--id-param` | - | ジョブIDパラメータ名 | `request_id` |
 | `--save-logs` | - | `{{output}}/logs/` にログ保存 | 無効 |
 | `--save-logs-inline` | - | 出力ファイル横にログ保存 | 無効 |
 | `--queue-config` | - | queue_config.jsonへのパス | ラッパー自動設定 |
@@ -1008,7 +1006,6 @@ def generate_wrapper_script(mcp_config: dict, tools: list[dict], skill_name: str
     """Generate convenience wrapper script that delegates to mcp_async_call.py."""
     endpoint = mcp_config.get("url") or mcp_config.get("endpoint", "")
     pattern = identify_async_pattern(tools)
-    id_param_name = detect_id_param_name(tools)
 
     # Get auth headers for --header arguments
     all_headers = mcp_config.get("all_headers", {})
@@ -1055,7 +1052,6 @@ DEFAULTS = [
     ("--submit-tool", "{pattern['submit'][0] if pattern['submit'] else 'submit'}"),
     ("--status-tool", "{pattern['status'][0] if pattern['status'] else 'status'}"),
     ("--result-tool", "{pattern['result'][0] if pattern['result'] else 'result'}"),
-    ("--id-param", "{id_param_name}"),
     ("--queue-config", os.path.join(os.path.dirname(os.path.dirname(__file__)), "queue_config.json")),
 {header_defaults_str}
 ]

--- a/.claude/skills/mcp-async-skill/scripts/mcp_async_call.py
+++ b/.claude/skills/mcp-async-skill/scripts/mcp_async_call.py
@@ -871,7 +871,6 @@ def route_execution(
     auto_filename: bool = False,
     poll_interval: float = 2.0,
     max_polls: int = 300,
-    id_param_name: str = "request_id",
     save_logs_to_dir: bool = False,
     save_logs_inline: bool = False,
 ) -> dict:
@@ -948,7 +947,6 @@ def route_execution(
         poll_interval=poll_interval,
         max_polls=max_polls,
         headers=headers,
-        id_param_name=id_param_name,
         save_logs_to_dir=save_logs_to_dir,
         save_logs_inline=save_logs_inline,
     )

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_mcp_async_call_queue.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_mcp_async_call_queue.py
@@ -131,7 +131,7 @@ class TestRouting(unittest.TestCase):
                 auto_filename=False,
                 poll_interval=2.0,
                 max_polls=300,
-                id_param_name="request_id",
+
                 save_logs_to_dir=False,
                 save_logs_inline=False,
             )
@@ -159,7 +159,7 @@ class TestRouting(unittest.TestCase):
                 auto_filename=False,
                 poll_interval=2.0,
                 max_polls=300,
-                id_param_name="request_id",
+
                 save_logs_to_dir=False,
                 save_logs_inline=False,
             )
@@ -187,7 +187,7 @@ class TestRouting(unittest.TestCase):
                 auto_filename=False,
                 poll_interval=2.0,
                 max_polls=300,
-                id_param_name="request_id",
+
                 save_logs_to_dir=False,
                 save_logs_inline=False,
             )
@@ -214,7 +214,7 @@ class TestRouting(unittest.TestCase):
                 auto_filename=False,
                 poll_interval=2.0,
                 max_polls=300,
-                id_param_name="request_id",
+
                 save_logs_to_dir=False,
                 save_logs_inline=False,
             )
@@ -358,7 +358,7 @@ class TestRouteListStats(unittest.TestCase):
                 auto_filename=False,
                 poll_interval=2.0,
                 max_polls=300,
-                id_param_name="request_id",
+
                 save_logs_to_dir=False,
                 save_logs_inline=False,
             )
@@ -387,7 +387,7 @@ class TestRouteListStats(unittest.TestCase):
                 auto_filename=False,
                 poll_interval=2.0,
                 max_polls=300,
-                id_param_name="request_id",
+
                 save_logs_to_dir=False,
                 save_logs_inline=False,
             )


### PR DESCRIPTION
## Summary
- `generate_wrapper_script()` の DEFAULTS から `--id-param` 行を削除（`build_parser()` に未登録のため実行時エラーになる）
- `route_execution()` から `id_param_name` パラメータを削除（`run_async_mcp_job()` が受け付けないため TypeError になる）
- `_usage` options dict と SKILL.md CLI Options テーブルから `--id-param` 参照を削除
- テストの `route_execution()` 呼び出しから `id_param_name` を削除

## Test plan
- [x] `python3 -m unittest discover -s .claude/skills/mcp-async-skill/scripts/tests/ -v` — 192/193 pass (1 flaky pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)