### PR TITLE
refs #24 #25 SQLite fallback + --show-args

### DIFF
--- a/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
@@ -56,26 +56,33 @@ class _RequestHandler(BaseHTTPRequestHandler):
             endpoint_filter = params.get("endpoint", [None])[0]
             limit_str = params.get("limit", [None])[0]
             limit = int(limit_str) if limit_str else None
+            include_args = params.get("include_args", [None])[0] in ("true", "1")
 
             jobs = app.store.get_all_jobs(
                 status=status_filter,
                 endpoint=endpoint_filter,
                 limit=limit,
             )
+            job_list = []
+            for j in jobs:
+                entry = {
+                    "job_id": j["id"],
+                    "endpoint": j["endpoint"],
+                    "submit_tool": j["submit_tool"],
+                    "status": j["status"],
+                    "created_at": j["created_at"],
+                    "updated_at": j["updated_at"],
+                    "error": j["error"],
+                }
+                if include_args:
+                    try:
+                        entry["args"] = json.loads(j["args"])
+                    except (json.JSONDecodeError, TypeError):
+                        entry["args"] = j["args"]
+                job_list.append(entry)
             self._send_json(200, {
                 "total": len(jobs),
-                "jobs": [
-                    {
-                        "job_id": j["id"],
-                        "endpoint": j["endpoint"],
-                        "submit_tool": j["submit_tool"],
-                        "status": j["status"],
-                        "created_at": j["created_at"],
-                        "updated_at": j["updated_at"],
-                        "error": j["error"],
-                    }
-                    for j in jobs
-                ],
+                "jobs": job_list,
             })
             return
 
@@ -85,18 +92,29 @@ class _RequestHandler(BaseHTTPRequestHandler):
             return
 
         if self.path.startswith("/api/jobs/"):
-            job_id = self.path[len("/api/jobs/"):]
+            from urllib.parse import urlparse as _urlparse, parse_qs as _parse_qs
+            _parsed = _urlparse(self.path)
+            job_id = _parsed.path[len("/api/jobs/"):]
+            _params = _parse_qs(_parsed.query)
+            _include_args = _params.get("include_args", [None])[0] in ("true", "1")
+
             job = app.store.get_job(job_id)
             if job is None:
                 self._send_json(404, {"error": "Job not found"})
                 return
-            self._send_json(200, {
+            resp_data = {
                 "job_id": job["id"],
                 "status": job["status"],
                 "result": job["result"],
                 "error": job["error"],
                 "remote_job_id": job["remote_job_id"],
-            })
+            }
+            if _include_args:
+                try:
+                    resp_data["args"] = json.loads(job["args"])
+                except (json.JSONDecodeError, TypeError):
+                    resp_data["args"] = job["args"]
+            self._send_json(200, resp_data)
             return
 
         self._send_json(404, {"error": "Not found"})

--- a/.claude/skills/mcp-async-skill/scripts/mcp_async_call.py
+++ b/.claude/skills/mcp-async-skill/scripts/mcp_async_call.py
@@ -801,27 +801,167 @@ def _queue_submit_only(
     )
 
 
-def _queue_wait(worker_url: str, job_id: str) -> dict:
-    """Query a job's status from the queue."""
-    from job_queue.client import wait_job
-    return wait_job(worker_url=worker_url, job_id=job_id)
+def _resolve_db_path(queue_config_path: str | None = None) -> str | None:
+    """Resolve the path to jobs.db for SQLite fallback.
+
+    Searches for the project root via ``queue_config_path`` (if given) or
+    the current working directory, then checks for ``.claude/queue/jobs.db``.
+    """
+    from mcp_worker_daemon import find_project_root
+
+    if queue_config_path and os.path.exists(queue_config_path):
+        project_root = find_project_root(queue_config_path)
+        db_path = os.path.join(project_root, ".claude", "queue", "jobs.db")
+        if os.path.exists(db_path):
+            return db_path
+
+    project_root = find_project_root(os.getcwd())
+    db_path = os.path.join(project_root, ".claude", "queue", "jobs.db")
+    if os.path.exists(db_path):
+        return db_path
+
+    return None
 
 
-def _queue_list(worker_url: str, status_filter: str | None = None) -> dict:
-    """List all jobs from the queue worker."""
-    url = f"{worker_url}/api/jobs"
-    if status_filter:
-        url += f"?status={status_filter}"
-    resp = requests.get(url, timeout=10)
-    resp.raise_for_status()
-    return resp.json()
+def _queue_list_fallback(
+    status_filter: str | None,
+    include_args: bool,
+    queue_config_path: str | None,
+) -> dict:
+    """Read job list directly from SQLite when the worker is unreachable."""
+    db_path = _resolve_db_path(queue_config_path)
+    if db_path is None:
+        return {"total": 0, "jobs": [], "_fallback": True,
+                "error": "Worker unreachable and jobs.db not found"}
+
+    from job_queue.db import JobStore
+    store = JobStore(db_path)
+    try:
+        jobs = store.get_all_jobs(status=status_filter)
+        job_list = []
+        for j in jobs:
+            entry = {
+                "job_id": j["id"],
+                "endpoint": j["endpoint"],
+                "submit_tool": j["submit_tool"],
+                "status": j["status"],
+                "created_at": j["created_at"],
+                "updated_at": j["updated_at"],
+                "error": j["error"],
+            }
+            if include_args:
+                try:
+                    entry["args"] = json.loads(j["args"])
+                except (json.JSONDecodeError, TypeError):
+                    entry["args"] = j["args"]
+            job_list.append(entry)
+        return {"total": len(job_list), "jobs": job_list, "_fallback": True}
+    finally:
+        store.close()
 
 
-def _queue_stats(worker_url: str) -> dict:
-    """Get per-endpoint statistics from the queue worker."""
-    resp = requests.get(f"{worker_url}/api/stats", timeout=10)
-    resp.raise_for_status()
-    return resp.json()
+def _queue_stats_fallback(queue_config_path: str | None) -> dict:
+    """Read per-endpoint stats directly from SQLite when the worker is unreachable."""
+    db_path = _resolve_db_path(queue_config_path)
+    if db_path is None:
+        return {"endpoints": [], "_fallback": True,
+                "error": "Worker unreachable and jobs.db not found"}
+
+    from job_queue.db import JobStore
+    store = JobStore(db_path)
+    try:
+        stats = store.get_stats_by_endpoint()
+        return {"endpoints": stats, "_fallback": True}
+    finally:
+        store.close()
+
+
+def _queue_wait_fallback(
+    job_id: str,
+    include_args: bool,
+    queue_config_path: str | None,
+) -> dict:
+    """Read a single job directly from SQLite when the worker is unreachable."""
+    db_path = _resolve_db_path(queue_config_path)
+    if db_path is None:
+        return {"error": "Worker unreachable and jobs.db not found",
+                "_fallback": True}
+
+    from job_queue.db import JobStore
+    store = JobStore(db_path)
+    try:
+        job = store.get_job(job_id)
+        if job is None:
+            return {"error": "Job not found", "_fallback": True}
+        resp = {
+            "job_id": job["id"],
+            "status": job["status"],
+            "result": job["result"],
+            "error": job["error"],
+            "remote_job_id": job["remote_job_id"],
+            "_fallback": True,
+        }
+        if include_args:
+            try:
+                resp["args"] = json.loads(job["args"])
+            except (json.JSONDecodeError, TypeError):
+                resp["args"] = job["args"]
+        return resp
+    finally:
+        store.close()
+
+
+def _queue_wait(
+    worker_url: str,
+    job_id: str,
+    include_args: bool = False,
+    queue_config_path: str | None = None,
+) -> dict:
+    """Query a job's status from the queue, with SQLite fallback."""
+    try:
+        url = f"{worker_url}/api/jobs/{job_id}"
+        if include_args:
+            url += "?include_args=true"
+        resp = requests.get(url, timeout=10)
+        return resp.json()
+    except (requests.ConnectionError, requests.Timeout):
+        return _queue_wait_fallback(job_id, include_args, queue_config_path)
+
+
+def _queue_list(
+    worker_url: str,
+    status_filter: str | None = None,
+    include_args: bool = False,
+    queue_config_path: str | None = None,
+) -> dict:
+    """List all jobs from the queue worker, with SQLite fallback."""
+    try:
+        url = f"{worker_url}/api/jobs"
+        params = {}
+        if status_filter:
+            params["status"] = status_filter
+        if include_args:
+            params["include_args"] = "true"
+        if params:
+            url += "?" + "&".join(f"{k}={v}" for k, v in params.items())
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except (requests.ConnectionError, requests.Timeout):
+        return _queue_list_fallback(status_filter, include_args, queue_config_path)
+
+
+def _queue_stats(
+    worker_url: str,
+    queue_config_path: str | None = None,
+) -> dict:
+    """Get per-endpoint statistics from the queue worker, with SQLite fallback."""
+    try:
+        resp = requests.get(f"{worker_url}/api/stats", timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except (requests.ConnectionError, requests.Timeout):
+        return _queue_stats_fallback(queue_config_path)
 
 
 def _queue_blocking(
@@ -901,6 +1041,7 @@ def route_execution(
     list_jobs: bool = False,
     show_stats: bool = False,
     filter_status: str | None = None,
+    show_args: bool = False,
     endpoint: str | None = None,
     submit_tool: str | None = None,
     submit_args: dict | None = None,
@@ -919,9 +1060,13 @@ def route_execution(
     submit_args = submit_args or {}
     headers = headers or {}
 
-    # Auto-start worker daemon if any queue mode is active
+    # Read-only operations (--list / --stats / --wait) do NOT auto-start
+    # the worker; they fall back to SQLite when the worker is unreachable.
+    is_read_only = bool(list_jobs or show_stats or wait_job_id)
+
+    # Auto-start worker daemon only for write operations
     needs_worker = bool(
-        worker_url or queue_config_path or list_jobs or show_stats or wait_job_id
+        (worker_url or queue_config_path) and not is_read_only
     )
     if needs_worker:
         resolved_url = (
@@ -934,17 +1079,20 @@ def route_execution(
     # --list mode
     if list_jobs:
         url = worker_url or resolve_worker_url(None, queue_config_path) or "http://127.0.0.1:54321"
-        return _queue_list(url, status_filter=filter_status)
+        return _queue_list(url, status_filter=filter_status,
+                           include_args=show_args,
+                           queue_config_path=queue_config_path)
 
     # --stats mode
     if show_stats:
         url = worker_url or resolve_worker_url(None, queue_config_path) or "http://127.0.0.1:54321"
-        return _queue_stats(url)
+        return _queue_stats(url, queue_config_path=queue_config_path)
 
     # --wait mode
     if wait_job_id:
         url = worker_url or resolve_worker_url(None, queue_config_path) or "http://127.0.0.1:54321"
-        return _queue_wait(url, wait_job_id)
+        return _queue_wait(url, wait_job_id, include_args=show_args,
+                           queue_config_path=queue_config_path)
 
     # Queue mode (--queue-config or --worker-url provided)
     if worker_url or queue_config_path:
@@ -1050,6 +1198,8 @@ Examples:
     queue_group.add_argument("--list", action="store_true", help="List all jobs in the queue")
     queue_group.add_argument("--stats", action="store_true", help="Show per-endpoint statistics")
     queue_group.add_argument("--filter-status", help="Filter jobs by status (used with --list)")
+    queue_group.add_argument("--show-args", action="store_true",
+                             help="Include original submit args in --list / --wait responses")
 
     return parser
 
@@ -1058,27 +1208,28 @@ def main():
     parser = build_parser()
     args = parser.parse_args()
 
-    # --list mode needs minimal args
+    # --list mode needs minimal args (no worker auto-start; falls back to SQLite)
     if args.list:
         worker_url = resolve_worker_url(args.worker_url, args.queue_config) or "http://127.0.0.1:54321"
-        _ensure_worker_running(worker_url, args.queue_config)
-        result = _queue_list(worker_url, status_filter=args.filter_status)
+        result = _queue_list(worker_url, status_filter=args.filter_status,
+                             include_args=args.show_args,
+                             queue_config_path=args.queue_config)
         print(json.dumps(result, indent=2, ensure_ascii=False))
         return
 
-    # --stats mode needs minimal args
+    # --stats mode needs minimal args (no worker auto-start; falls back to SQLite)
     if args.stats:
         worker_url = resolve_worker_url(args.worker_url, args.queue_config) or "http://127.0.0.1:54321"
-        _ensure_worker_running(worker_url, args.queue_config)
-        result = _queue_stats(worker_url)
+        result = _queue_stats(worker_url, queue_config_path=args.queue_config)
         print(json.dumps(result, indent=2, ensure_ascii=False))
         return
 
-    # --wait mode needs minimal args
+    # --wait mode needs minimal args (no worker auto-start; falls back to SQLite)
     if args.wait:
         worker_url = resolve_worker_url(args.worker_url, args.queue_config) or "http://127.0.0.1:54321"
-        _ensure_worker_running(worker_url, args.queue_config)
-        result = _queue_wait(worker_url, args.wait)
+        result = _queue_wait(worker_url, args.wait,
+                             include_args=args.show_args,
+                             queue_config_path=args.queue_config)
         print(json.dumps(result, indent=2, ensure_ascii=False))
         return
 
@@ -1131,6 +1282,7 @@ def main():
         queue_config_path=args.queue_config,
         submit_only=args.submit_only,
         wait_job_id=None,
+        show_args=args.show_args,
         endpoint=endpoint,
         submit_tool=args.submit_tool,
         submit_args=submit_args,

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_mcp_async_call_queue.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_mcp_async_call_queue.py
@@ -522,6 +522,433 @@ class TestRateLimitsPassthrough(unittest.TestCase):
         self.assertIn("job_id", result)
 
 
+# ── 5-6. SQLite Fallback Tests ────────────────────────────────────────
+
+class TestSqliteFallbackList(unittest.TestCase):
+    """_queue_list falls back to SQLite when the worker is unreachable."""
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+        # Create a .claude/queue/ structure with a real jobs.db
+        self.queue_dir = os.path.join(self.tmpdir, ".claude", "queue")
+        os.makedirs(self.queue_dir)
+        self.db_path = os.path.join(self.queue_dir, "jobs.db")
+
+        from job_queue.db import JobStore
+        store = JobStore(self.db_path)
+        store.insert_job(
+            endpoint="http://mcp:8000",
+            submit_tool="gen",
+            args='{"prompt":"hello"}',
+            status_tool="status",
+            result_tool="result",
+        )
+        store.close()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_fallback_returns_jobs(self):
+        from mcp_async_call import _queue_list
+        with mock.patch("mcp_async_call.requests.get", side_effect=requests.ConnectionError("refused")):
+            with mock.patch("mcp_async_call._resolve_db_path", return_value=self.db_path):
+                result = _queue_list("http://127.0.0.1:54321",
+                                     queue_config_path=None)
+        self.assertIn("jobs", result)
+        self.assertEqual(result["total"], 1)
+        self.assertTrue(result.get("_fallback"))
+        self.assertNotIn("args", result["jobs"][0])
+
+    def test_fallback_with_include_args(self):
+        from mcp_async_call import _queue_list
+        with mock.patch("mcp_async_call.requests.get", side_effect=requests.ConnectionError("refused")):
+            with mock.patch("mcp_async_call._resolve_db_path", return_value=self.db_path):
+                result = _queue_list("http://127.0.0.1:54321",
+                                     include_args=True,
+                                     queue_config_path=None)
+        self.assertIn("args", result["jobs"][0])
+        self.assertEqual(result["jobs"][0]["args"]["prompt"], "hello")
+
+    def test_fallback_with_status_filter(self):
+        from mcp_async_call import _queue_list
+        with mock.patch("mcp_async_call.requests.get", side_effect=requests.ConnectionError("refused")):
+            with mock.patch("mcp_async_call._resolve_db_path", return_value=self.db_path):
+                result = _queue_list("http://127.0.0.1:54321",
+                                     status_filter="completed",
+                                     queue_config_path=None)
+        # No completed jobs, so list should be empty
+        self.assertEqual(result["total"], 0)
+
+
+class TestSqliteFallbackStats(unittest.TestCase):
+    """_queue_stats falls back to SQLite when the worker is unreachable."""
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+        self.queue_dir = os.path.join(self.tmpdir, ".claude", "queue")
+        os.makedirs(self.queue_dir)
+        self.db_path = os.path.join(self.queue_dir, "jobs.db")
+
+        from job_queue.db import JobStore
+        store = JobStore(self.db_path)
+        store.insert_job(
+            endpoint="http://mcp:8000",
+            submit_tool="gen",
+            args='{"prompt":"hello"}',
+        )
+        store.close()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_fallback_returns_stats(self):
+        from mcp_async_call import _queue_stats
+        with mock.patch("mcp_async_call.requests.get", side_effect=requests.ConnectionError("refused")):
+            with mock.patch("mcp_async_call._resolve_db_path", return_value=self.db_path):
+                result = _queue_stats("http://127.0.0.1:54321",
+                                      queue_config_path=None)
+        self.assertIn("endpoints", result)
+        self.assertTrue(result.get("_fallback"))
+        self.assertGreaterEqual(len(result["endpoints"]), 1)
+        self.assertEqual(result["endpoints"][0]["endpoint"], "http://mcp:8000")
+
+
+class TestSqliteFallbackWait(unittest.TestCase):
+    """_queue_wait falls back to SQLite when the worker is unreachable."""
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+        self.queue_dir = os.path.join(self.tmpdir, ".claude", "queue")
+        os.makedirs(self.queue_dir)
+        self.db_path = os.path.join(self.queue_dir, "jobs.db")
+
+        from job_queue.db import JobStore
+        store = JobStore(self.db_path)
+        self.job_id = store.insert_job(
+            endpoint="http://mcp:8000",
+            submit_tool="gen",
+            args='{"prompt":"test_wait"}',
+        )
+        store.close()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_fallback_returns_job(self):
+        from mcp_async_call import _queue_wait
+        with mock.patch("mcp_async_call.requests.get", side_effect=requests.ConnectionError("refused")):
+            with mock.patch("mcp_async_call._resolve_db_path", return_value=self.db_path):
+                result = _queue_wait("http://127.0.0.1:54321",
+                                     self.job_id,
+                                     queue_config_path=None)
+        self.assertEqual(result["job_id"], self.job_id)
+        self.assertEqual(result["status"], "pending")
+        self.assertTrue(result.get("_fallback"))
+
+    def test_fallback_with_include_args(self):
+        from mcp_async_call import _queue_wait
+        with mock.patch("mcp_async_call.requests.get", side_effect=requests.ConnectionError("refused")):
+            with mock.patch("mcp_async_call._resolve_db_path", return_value=self.db_path):
+                result = _queue_wait("http://127.0.0.1:54321",
+                                     self.job_id,
+                                     include_args=True,
+                                     queue_config_path=None)
+        self.assertIn("args", result)
+        self.assertEqual(result["args"]["prompt"], "test_wait")
+
+    def test_fallback_nonexistent_job(self):
+        from mcp_async_call import _queue_wait
+        with mock.patch("mcp_async_call.requests.get", side_effect=requests.ConnectionError("refused")):
+            with mock.patch("mcp_async_call._resolve_db_path", return_value=self.db_path):
+                result = _queue_wait("http://127.0.0.1:54321",
+                                     "nonexistent-id",
+                                     queue_config_path=None)
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "Job not found")
+
+
+class TestSqliteFallbackNoDb(unittest.TestCase):
+    """Fallback when jobs.db does not exist."""
+
+    def test_list_fallback_no_db(self):
+        from mcp_async_call import _queue_list
+        with mock.patch("mcp_async_call.requests.get", side_effect=requests.ConnectionError("refused")):
+            with mock.patch("mcp_async_call._resolve_db_path", return_value=None):
+                result = _queue_list("http://127.0.0.1:54321",
+                                     queue_config_path=None)
+        self.assertEqual(result["total"], 0)
+        self.assertIn("error", result)
+
+    def test_stats_fallback_no_db(self):
+        from mcp_async_call import _queue_stats
+        with mock.patch("mcp_async_call.requests.get", side_effect=requests.ConnectionError("refused")):
+            with mock.patch("mcp_async_call._resolve_db_path", return_value=None):
+                result = _queue_stats("http://127.0.0.1:54321",
+                                      queue_config_path=None)
+        self.assertEqual(result["endpoints"], [])
+        self.assertIn("error", result)
+
+    def test_wait_fallback_no_db(self):
+        from mcp_async_call import _queue_wait
+        with mock.patch("mcp_async_call.requests.get", side_effect=requests.ConnectionError("refused")):
+            with mock.patch("mcp_async_call._resolve_db_path", return_value=None):
+                result = _queue_wait("http://127.0.0.1:54321",
+                                     "some-id",
+                                     queue_config_path=None)
+        self.assertIn("error", result)
+
+
+# ── 5-7. --show-args CLI Parsing ─────────────────────────────────────
+
+class TestShowArgsFlag(unittest.TestCase):
+    """--show-args flag is accepted and wired to route_execution."""
+
+    def _parse(self, args_list: list[str]):
+        from mcp_async_call import build_parser
+        return build_parser().parse_args(args_list)
+
+    def test_show_args_default_false(self):
+        args = self._parse(["--list", "--queue-config", "q.json"])
+        self.assertFalse(args.show_args)
+
+    def test_show_args_true(self):
+        args = self._parse(["--list", "--queue-config", "q.json", "--show-args"])
+        self.assertTrue(args.show_args)
+
+    def test_show_args_with_wait(self):
+        args = self._parse(["--wait", "abc", "--show-args"])
+        self.assertTrue(args.show_args)
+
+    def test_route_list_passes_show_args(self):
+        from mcp_async_call import route_execution
+        with mock.patch("mcp_async_call._queue_list") as m:
+            m.return_value = {"total": 0, "jobs": []}
+            route_execution(
+                worker_url="http://127.0.0.1:54321",
+                queue_config_path="q.json",
+                submit_only=False,
+                wait_job_id=None,
+                list_jobs=True,
+                show_args=True,
+                endpoint=None,
+                submit_tool=None,
+                submit_args={},
+                status_tool=None,
+                result_tool=None,
+                headers={},
+                output_dir="./output",
+                output_file=None,
+                auto_filename=False,
+                poll_interval=2.0,
+                max_polls=300,
+                save_logs_to_dir=False,
+                save_logs_inline=False,
+            )
+            # Verify include_args=True was passed
+            call_kwargs = m.call_args
+            self.assertTrue(call_kwargs[1].get("include_args") or
+                            (len(call_kwargs[0]) > 2 and call_kwargs[0][2]))
+
+    def test_route_wait_passes_show_args(self):
+        from mcp_async_call import route_execution
+        with mock.patch("mcp_async_call._queue_wait") as m:
+            m.return_value = {"job_id": "abc", "status": "completed"}
+            route_execution(
+                worker_url="http://127.0.0.1:54321",
+                queue_config_path="q.json",
+                submit_only=False,
+                wait_job_id="abc",
+                show_args=True,
+                endpoint=None,
+                submit_tool=None,
+                submit_args={},
+                status_tool=None,
+                result_tool=None,
+                headers={},
+                output_dir="./output",
+                output_file=None,
+                auto_filename=False,
+                poll_interval=2.0,
+                max_polls=300,
+                save_logs_to_dir=False,
+                save_logs_inline=False,
+            )
+            call_kwargs = m.call_args
+            self.assertTrue(call_kwargs[1].get("include_args") or
+                            (len(call_kwargs[0]) > 2 and call_kwargs[0][2]))
+
+
+# ── 5-8. Read-only operations do NOT auto-start worker ───────────────
+
+class TestReadOnlyNoAutoStart(unittest.TestCase):
+    """--list/--stats/--wait should NOT call _ensure_worker_running."""
+
+    def test_list_no_autostart(self):
+        from mcp_async_call import route_execution
+        with mock.patch("mcp_async_call._queue_list") as m_list, \
+             mock.patch("mcp_async_call._ensure_worker_running") as m_ensure:
+            m_list.return_value = {"total": 0, "jobs": []}
+            route_execution(
+                worker_url="http://127.0.0.1:54321",
+                queue_config_path="q.json",
+                submit_only=False,
+                wait_job_id=None,
+                list_jobs=True,
+                endpoint=None,
+                submit_tool=None,
+                submit_args={},
+                status_tool=None,
+                result_tool=None,
+                headers={},
+                output_dir="./output",
+                output_file=None,
+                auto_filename=False,
+                poll_interval=2.0,
+                max_polls=300,
+                save_logs_to_dir=False,
+                save_logs_inline=False,
+            )
+            m_ensure.assert_not_called()
+
+    def test_stats_no_autostart(self):
+        from mcp_async_call import route_execution
+        with mock.patch("mcp_async_call._queue_stats") as m_stats, \
+             mock.patch("mcp_async_call._ensure_worker_running") as m_ensure:
+            m_stats.return_value = {"endpoints": []}
+            route_execution(
+                worker_url="http://127.0.0.1:54321",
+                queue_config_path="q.json",
+                submit_only=False,
+                wait_job_id=None,
+                show_stats=True,
+                endpoint=None,
+                submit_tool=None,
+                submit_args={},
+                status_tool=None,
+                result_tool=None,
+                headers={},
+                output_dir="./output",
+                output_file=None,
+                auto_filename=False,
+                poll_interval=2.0,
+                max_polls=300,
+                save_logs_to_dir=False,
+                save_logs_inline=False,
+            )
+            m_ensure.assert_not_called()
+
+    def test_wait_no_autostart(self):
+        from mcp_async_call import route_execution
+        with mock.patch("mcp_async_call._queue_wait") as m_wait, \
+             mock.patch("mcp_async_call._ensure_worker_running") as m_ensure:
+            m_wait.return_value = {"job_id": "abc", "status": "pending"}
+            route_execution(
+                worker_url="http://127.0.0.1:54321",
+                queue_config_path="q.json",
+                submit_only=False,
+                wait_job_id="abc",
+                endpoint=None,
+                submit_tool=None,
+                submit_args={},
+                status_tool=None,
+                result_tool=None,
+                headers={},
+                output_dir="./output",
+                output_file=None,
+                auto_filename=False,
+                poll_interval=2.0,
+                max_polls=300,
+                save_logs_to_dir=False,
+                save_logs_inline=False,
+            )
+            m_ensure.assert_not_called()
+
+
+# ── 5-9. E2E: --show-args with live worker ──────────────────────────
+
+class TestE2EShowArgs(unittest.TestCase):
+    """E2E test for include_args with a running worker."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.port = get_free_port()
+        cls.worker_url = f"http://127.0.0.1:{cls.port}"
+
+        def mock_executor(job):
+            cls.worker_app.store.update_status(
+                job["id"], "completed",
+                result=json.dumps({"urls": ["https://example.com/img.png"]}),
+            )
+
+        cls.worker_app = worker.WorkerApp(
+            host="127.0.0.1",
+            port=cls.port,
+            db_path=":memory:",
+            config_dict={
+                "default_rate_limit": {
+                    "max_concurrent_jobs": 5,
+                    "min_interval_seconds": 0.0,
+                },
+            },
+            job_executor=mock_executor,
+            idle_timeout=0,
+        )
+        cls.worker_app.start()
+        for _ in range(50):
+            try:
+                requests.get(f"{cls.worker_url}/api/health", timeout=0.5)
+                break
+            except requests.ConnectionError:
+                time.sleep(0.05)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.worker_app.stop()
+
+    def test_e2e_list_with_show_args(self):
+        from mcp_async_call import _queue_submit_only, _queue_list
+        _queue_submit_only(
+            worker_url=self.worker_url,
+            endpoint="http://mcp:8000/sse",
+            submit_tool="gen",
+            submit_args={"prompt": "e2e_args_test"},
+            status_tool=None,
+            result_tool=None,
+            headers=None,
+        )
+        time.sleep(0.5)
+        result = _queue_list(self.worker_url, include_args=True)
+        self.assertGreaterEqual(result["total"], 1)
+        found = any(
+            j.get("args", {}).get("prompt") == "e2e_args_test"
+            for j in result["jobs"]
+        )
+        self.assertTrue(found)
+
+    def test_e2e_wait_with_show_args(self):
+        from mcp_async_call import _queue_submit_only, _queue_wait
+        submit_result = _queue_submit_only(
+            worker_url=self.worker_url,
+            endpoint="http://mcp:8000/sse",
+            submit_tool="gen",
+            submit_args={"prompt": "e2e_wait_args"},
+            status_tool=None,
+            result_tool=None,
+            headers=None,
+        )
+        job_id = submit_result["job_id"]
+        time.sleep(0.5)
+        result = _queue_wait(self.worker_url, job_id, include_args=True)
+        self.assertIn("args", result)
+        self.assertEqual(result["args"]["prompt"], "e2e_wait_args")
+
+
 class TestFindProjectRoot(unittest.TestCase):
     """Verify find_project_root() traverses upward to find .claude/ dir."""
 

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_worker.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_worker.py
@@ -517,5 +517,66 @@ class TestResultsDir(unittest.TestCase):
         self.assertIsNone(app.results_dir)
 
 
+class TestIncludeArgs(WorkerTestBase):
+    """GET /api/jobs and /api/jobs/{id} with include_args query param."""
+
+    def test_list_jobs_without_include_args(self):
+        """Default response should NOT contain args field."""
+        requests.post(
+            f"{self.base_url}/api/jobs",
+            json={"endpoint": "http://mcp:8000", "submit_tool": "gen",
+                   "args": {"prompt": "hello"}},
+        )
+        time.sleep(0.3)
+        resp = requests.get(f"{self.base_url}/api/jobs")
+        data = resp.json()
+        self.assertGreaterEqual(len(data["jobs"]), 1)
+        for job in data["jobs"]:
+            self.assertNotIn("args", job)
+
+    def test_list_jobs_with_include_args(self):
+        """include_args=true should add args field to each job."""
+        requests.post(
+            f"{self.base_url}/api/jobs",
+            json={"endpoint": "http://mcp:8000", "submit_tool": "gen",
+                   "args": {"prompt": "world"}},
+        )
+        time.sleep(0.3)
+        resp = requests.get(f"{self.base_url}/api/jobs?include_args=true")
+        data = resp.json()
+        self.assertGreaterEqual(len(data["jobs"]), 1)
+        found = False
+        for job in data["jobs"]:
+            self.assertIn("args", job)
+            if isinstance(job["args"], dict) and job["args"].get("prompt") == "world":
+                found = True
+        self.assertTrue(found, "Expected to find job with prompt='world'")
+
+    def test_single_job_without_include_args(self):
+        """GET /api/jobs/{id} default should NOT contain args."""
+        submit_resp = requests.post(
+            f"{self.base_url}/api/jobs",
+            json={"endpoint": "http://mcp:8000", "submit_tool": "gen",
+                   "args": {"prompt": "test"}},
+        )
+        job_id = submit_resp.json()["job_id"]
+        resp = requests.get(f"{self.base_url}/api/jobs/{job_id}")
+        data = resp.json()
+        self.assertNotIn("args", data)
+
+    def test_single_job_with_include_args(self):
+        """GET /api/jobs/{id}?include_args=true should contain args."""
+        submit_resp = requests.post(
+            f"{self.base_url}/api/jobs",
+            json={"endpoint": "http://mcp:8000", "submit_tool": "gen",
+                   "args": {"prompt": "test_args"}},
+        )
+        job_id = submit_resp.json()["job_id"]
+        resp = requests.get(f"{self.base_url}/api/jobs/{job_id}?include_args=true")
+        data = resp.json()
+        self.assertIn("args", data)
+        self.assertEqual(data["args"]["prompt"], "test_args")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- **Issue #24**: `--list` / `--stats` / `--wait` now fall back to reading `jobs.db` directly when the worker daemon is unreachable (idle timeout / stopped), instead of failing with `ConnectionRefusedError`. Read-only operations no longer auto-start the worker daemon.
- **Issue #25**: New `--show-args` CLI flag and `include_args=true` query param on `GET /api/jobs` and `GET /api/jobs/{id}`, so job responses can include the original submit arguments for identification after context compaction.

## Changes

| File | What changed |
|------|-------------|
| `scripts/mcp_async_call.py` | `_resolve_db_path()` helper, `_queue_*_fallback()` functions, SQLite try/except in `_queue_list`/`_queue_stats`/`_queue_wait`, `--show-args` argparse, wired through `route_execution()` + `main()`, removed `_ensure_worker_running` from read-only paths |
| `scripts/job_queue/worker.py` | `include_args` query param support on `GET /api/jobs` and `GET /api/jobs/{id}` |
| `scripts/tests/test_mcp_async_call_queue.py` | 20 new tests: SQLite fallback (list/stats/wait/no-db), `--show-args` parsing & routing, read-only no-autostart, E2E show-args |
| `scripts/tests/test_worker.py` | 4 new tests: `include_args` on list and single job endpoints |

## Test plan

- [x] All 217 tests pass (`python3 -m unittest discover -s .claude/skills/mcp-async-skill/scripts/tests/ -v`)
- [ ] Manual: stop worker, run `--list` → should return jobs from SQLite
- [ ] Manual: run `--list --show-args` → should include `args` field in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)