### PR TITLE
refs #24 #25 Document --show-args and SQLite fallback

### DIFF
--- a/.claude/skills/mcp-async-skill/SKILL.md
+++ b/.claude/skills/mcp-async-skill/SKILL.md
@@ -274,6 +274,7 @@ Main async MCP caller with full flow automation.
 - `--list`: List all jobs in the queue (JSON output)
 - `--stats`: Show per-endpoint statistics (JSON output)
 - `--filter-status`: Filter jobs by status (used with `--list`)
+- `--show-args`: Include original submit args in `--list` / `--wait` responses
 - `--blocking`: Submit → poll → download in one step (default, backward compatible)
 
 **File Extension Detection:**
@@ -383,6 +384,7 @@ Generated skills include a local queue system that prevents overloading MCP serv
 - The worker starts automatically on first use and stops after idle timeout (default: 60s)
 - Rate limits are configured per-endpoint in `queue_config.json`
 - Multiple skills share a single worker process and queue directory (`.claude/queue/`)
+- When the worker is stopped (idle timeout), `--list`, `--stats`, and `--wait` automatically fall back to reading from SQLite (`jobs.db`), so job data remains accessible without restarting the worker
 
 **Queue modes:**
 
@@ -404,6 +406,9 @@ python mcp_async_call.py --queue-config ../queue_config.json --list --filter-sta
 
 # Show per-endpoint statistics
 python mcp_async_call.py --queue-config ../queue_config.json --stats
+
+# List jobs with original submit args
+python mcp_async_call.py --queue-config ../queue_config.json --list --show-args
 ```
 
 **Robustness features:**

--- a/.claude/skills/mcp-async-skill/scripts/generate_skill.py
+++ b/.claude/skills/mcp-async-skill/scripts/generate_skill.py
@@ -403,8 +403,30 @@ def convert_tools_to_yaml_dict(tools: list[dict], mcp_config: dict = None, skill
                 "--wait JOB_ID": "ジョブ状態確認",
                 "--list": "キュー内ジョブ一覧（JSON出力）",
                 "--stats": "エンドポイント別統計情報",
+                "--filter-status": "ステータスフィルタ（--list使用時）",
+                "--show-args": "送信引数を表示（--list / --wait使用時）",
             },
             "notes": notes_dict,
+            "queue": {
+                "description": "ローカルキューシステムによるレートリミット制御",
+                "modes": {
+                    "default": "submit → poll → download（従来互換）",
+                    "submit_only": "--submit-only でjob_id即返却",
+                    "wait": "--wait JOB_ID でジョブ状態確認",
+                    "list": "--list でジョブ一覧（--filter-status, --show-args 併用可）",
+                    "stats": "--stats でエンドポイント別統計",
+                },
+                "robustness": [
+                    "接続エラー・503/504で指数バックオフリトライ (2s→4s→8s, 最大3回)",
+                    "429 Retry-After ヘッダー対応（エンドポイント単位で一時停止）",
+                    "ワーカー再起動時にゾンビジョブ自動回復（polling+remote_job_id有り→recovering）",
+                    "ワーカー側で結果ファイルをダウンロード (results/{job_id}/)",
+                    "起動時に古いジョブを自動削除（デフォルト保持期間: 24時間）",
+                    "ワーカー停止時は --list/--stats/--wait がSQLiteから直接読み取り",
+                ],
+                "config": "queue_config.json でレートリミット調整可能（スキル再生成時もユーザー設定を保持）",
+                "worker": "初回使用時に自動起動、アイドルタイムアウト（デフォルト60秒）で自動終了",
+            },
         }
 
     # Add tool definitions
@@ -810,6 +832,8 @@ python .claude/skills/{skill_name}/scripts/mcp_async_call.py \\
 | `--wait` | - | ジョブ状態確認（JOB_ID指定） | - |
 | `--list` | - | キュー内ジョブ一覧（JSON出力） | - |
 | `--stats` | - | エンドポイント別統計情報 | - |
+| `--filter-status` | - | `--list` 使用時にステータスでフィルタ | - |
+| `--show-args` | - | `--list` / `--wait` 使用時に送信引数を表示 | - |
 
 ### 出力パス決定ルール
 
@@ -936,6 +960,8 @@ This skill includes a local queue system that controls request rates to the MCP 
 - `--wait JOB_ID`: Check job status by ID
 - `--list`: List all jobs (with optional `--filter-status`)
 - `--stats`: Show per-endpoint statistics
+- `--show-args`: Include original submit args in `--list` / `--wait` output
+- `--filter-status STATUS`: Filter `--list` by job status
 
 **Robustness:**
 - Exponential backoff retry on connection errors and 503/504 (2s→4s→8s, max 3 retries)
@@ -948,6 +974,8 @@ This skill includes a local queue system that controls request rates to the MCP 
 Re-generating this skill preserves your customized queue_config.json settings.
 
 **Worker auto-start:** The queue worker starts automatically on first use and stops after idle timeout.
+
+**SQLite fallback:** When the worker is stopped, `--list`, `--stats`, and `--wait` read directly from SQLite. No need to restart the worker to check job status.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ python scripts/mcp_async_call.py \
 | `--list` | キュー内の全ジョブを一覧（JSON出力） |
 | `--stats` | エンドポイント別統計情報を表示 |
 | `--filter-status` | `--list`使用時にステータスでフィルタ |
+| `--show-args` | `--list` / `--wait` 使用時に元の送信引数を表示 |
 
 **拡張子の決定順序:**
 1. `--output-file` で指定されている場合はその拡張子
@@ -388,6 +389,7 @@ print(result["saved_path"])  # ダウンロードしたファイルへのパス
 - ローカルワーカーデーモン（port 54321）がHTTP APIでジョブを受け付け、エンドポイント別にレートリミットを適用
 - 初回使用時に自動起動、アイドルタイムアウト（デフォルト: 60秒）で自動終了
 - SQLiteでジョブ状態を永続化。複数スキルで共有キューディレクトリ（`.claude/queue/`）を使用
+- ワーカー停止時（アイドルタイムアウト後）でも `--list` / `--stats` / `--wait` はSQLiteから直接読み取りで動作
 
 ### キューモード
 
@@ -406,6 +408,9 @@ python mcp_async_call.py --queue-config ../queue_config.json --list
 
 # エンドポイント別統計
 python mcp_async_call.py --queue-config ../queue_config.json --stats
+
+# 送信引数付きでジョブ一覧
+python mcp_async_call.py --queue-config ../queue_config.json --list --show-args
 ```
 
 ### 堅牢化機能


### PR DESCRIPTION
## Summary

- `--show-args`、`--filter-status`、SQLite fallback の説明を全ドキュメントに追加
- lazy YAML に `_usage.queue` セクションを新設（通常SKILL.mdのQueue Systemセクションと同等の情報量）

## Changes

| File | What |
|------|------|
| `README.md` | オプション表に `--show-args`、キュー説明にSQLite fallback、使用例追加 |
| `SKILL.md` | Options一覧・Queue modes・SQLite fallback説明を追加 |
| `generate_skill.py` | 通常テンプレート: オプション表+Queue Modesに2行追加+SQLite fallback段落 / lazyテンプレート: options dictに2項目+`_usage.queue`セクション新設 |

## Test plan

- [x] `python3 -c "import ast; ..."` — generate_skill.py 構文OK
- [x] 217 tests pass
- [x] `convert_tools_to_yaml_dict()` で `_usage.queue` が正しく生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)