### PR TITLE
feat: pip-installable release package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Build Release Package
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Sync scripts to release directory
+        run: |
+          SRC=.claude/skills/mcp-async-skill
+          DST=release/claude/lazykamui/.claude/skills/mcp-async-skill
+
+          # Clean and recreate
+          rm -rf $DST/scripts $DST/SKILL.md
+          mkdir -p $DST/scripts/job_queue
+
+          # Copy scripts (no tests, no __pycache__)
+          cp $SRC/scripts/generate_skill.py $DST/scripts/
+          cp $SRC/scripts/mcp_async_call.py $DST/scripts/
+          cp $SRC/scripts/mcp_worker_daemon.py $DST/scripts/
+          cp $SRC/scripts/job_queue/__init__.py $DST/scripts/job_queue/
+          cp $SRC/scripts/job_queue/db.py $DST/scripts/job_queue/
+          cp $SRC/scripts/job_queue/dispatcher.py $DST/scripts/job_queue/
+          cp $SRC/scripts/job_queue/worker.py $DST/scripts/job_queue/
+          cp $SRC/scripts/job_queue/client.py $DST/scripts/job_queue/
+
+          # Copy SKILL.md
+          cp $SRC/SKILL.md $DST/
+
+      - name: Update version in pyproject.toml and __init__.py
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          sed -i "s/^version = .*/version = \"$VERSION\"/" release/claude/pyproject.toml
+          sed -i "s/^__version__ = .*/__version__ = \"$VERSION\"/" release/claude/lazykamui/__init__.py
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add release/claude/
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "release: update release/claude/ to ${{ github.ref_name }}"
+            git push origin HEAD:main
+            # Update tag to include release files
+            git tag -f ${{ github.ref_name }}
+            git push origin ${{ github.ref_name }} --force
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ output/
 mcp*.json
 tools*
 __pycache__/
+
+# Release build artifacts
+release/claude/lazykamui/.claude/

--- a/release/claude/MANIFEST.in
+++ b/release/claude/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include lazykamui/.claude *

--- a/release/claude/lazykamui/__init__.py
+++ b/release/claude/lazykamui/__init__.py
@@ -1,0 +1,2 @@
+"""LazyKamuiCodeSkillsCreator — MCP Skill Generator for Claude Code."""
+__version__ = "0.0.0"

--- a/release/claude/lazykamui/__main__.py
+++ b/release/claude/lazykamui/__main__.py
@@ -1,0 +1,2 @@
+from lazykamui.cli import main
+main()

--- a/release/claude/lazykamui/cli.py
+++ b/release/claude/lazykamui/cli.py
@@ -1,0 +1,17 @@
+"""CLI entry point for generate-skill command."""
+import sys
+import os
+
+
+def main():
+    scripts_dir = os.path.join(
+        os.path.dirname(__file__),
+        ".claude", "skills", "mcp-async-skill", "scripts",
+    )
+    sys.path.insert(0, scripts_dir)
+    from generate_skill import main as gen_main
+    gen_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/release/claude/pyproject.toml
+++ b/release/claude/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "LazyKamuiCodeSkillsCreator"
+version = "0.0.0"
+description = "MCP Skill Generator for Claude Code — async job pattern (submit/status/result)"
+requires-python = ">=3.9"
+dependencies = ["pyyaml", "requests"]
+license = {text = "MIT"}
+
+[project.scripts]
+generate-skill = "lazykamui.cli:main"
+
+[tool.setuptools]
+packages = ["lazykamui"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+lazykamui = [".claude/**/*"]


### PR DESCRIPTION
## Summary

- `release/claude/` に pip installable なパッケージを追加（`pip install git+...#subdirectory=release/claude`）
- `generate-skill` CLI コマンドと `python -m lazykamui` の両方をサポート
- `v*` タグ push 時に GitHub Actions でスクリプト同期 + バージョン書き換えを実行

refs #7

## 構成

| ファイル | 役割 |
|----------|------|
| `release/claude/pyproject.toml` | パッケージメタデータ、依存関係、エントリポイント |
| `release/claude/MANIFEST.in` | sdist に `.claude/` を含める |
| `release/claude/lazykamui/cli.py` | `generate_skill.main()` を呼ぶ薄いラッパー |
| `release/claude/lazykamui/__main__.py` | `python -m lazykamui` サポート |
| `.github/workflows/release.yml` | CI: スクリプト同期 → バージョン更新 → コミット → タグ更新 |
| `.gitignore` | CI 生成ファイルを除外 |

## Usage

```bash
# Install
pip install git+https://github.com/Yumeno/LazyKamuiCodeSkillsCreator.git@v1.0.0#subdirectory=release/claude

# Generate skills
generate-skill -m /path/to/.mcp.json
generate-skill -m /path/to/.mcp.json --lazy
python -m lazykamui -m /path/to/.mcp.json
```

## Test plan

- [x] 既存テスト 217 件 全パス
- [x] venv で `pip install -e .` 成功
- [x] `generate-skill --help` 動作確認
- [x] `python -m lazykamui --help` 動作確認
- [x] `import lazykamui; print(lazykamui.__version__)` → `0.0.0`
- [x] スクリプトの sibling ファイル解決（`generate_skill.py`, `mcp_async_call.py`, `job_queue/`）確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)