### PR TITLE
docs: pip install 導入手順とリリース作業手順書

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,20 +72,39 @@ python scripts/mcp_async_call.py \
 
 ## セットアップ
 
-### 1. リポジトリをクローン
+### 方法A: pip install（推奨）
+
+```bash
+# 最新版をインストール
+pip install git+https://github.com/Yumeno/LazyKamuiCodeSkillsCreator.git#subdirectory=release/claude
+
+# バージョン指定
+pip install git+https://github.com/Yumeno/LazyKamuiCodeSkillsCreator.git@v1.0.0#subdirectory=release/claude
+```
+
+インストール後は `generate-skill` コマンドが使えます：
+
+```bash
+# mcp.json内の全サーバーのスキルを生成
+generate-skill -m /path/to/your/.mcp.json
+
+# 特定のサーバーのみ生成
+generate-skill -m /path/to/your/.mcp.json -s fal-ai/flux-lora
+
+# Lazyモードで生成（コンテキスト節約）
+generate-skill -m /path/to/your/.mcp.json --lazy
+
+# python -m でも実行可能
+python -m lazykamui -m /path/to/your/.mcp.json
+```
+
+### 方法B: git clone（開発者向け）
 
 ```bash
 git clone https://github.com/Yumeno/LazyKamuiCodeSkillsCreator.git
 cd LazyKamuiCodeSkillsCreator
-```
-
-### 2. 依存パッケージをインストール
-
-```bash
 pip install pyyaml requests
 ```
-
-### 3. スキルを生成
 
 ```bash
 # mcp.json内の全サーバーのスキルを生成

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,128 @@
+# リリース作業手順
+
+新バージョンをリリースする手順です。
+
+## 前提
+
+- GitHub Actions ワークフロー（`.github/workflows/release.yml`）が設定済み
+- リリースパッケージのスケルトン（`release/claude/`）がコミット済み
+- main ブランチが最新の状態
+
+## 手順
+
+### 1. リリース内容の確認
+
+リリースに含めたい変更がすべて main にマージされていることを確認します。
+
+```bash
+git checkout main
+git pull
+```
+
+### 2. バージョンタグを作成・push
+
+`v` プレフィックス付きのセマンティックバージョニングタグを push します。
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+### 3. GitHub Actions の自動処理
+
+タグ push をトリガーに、以下が自動実行されます：
+
+1. **スクリプト同期** — `.claude/skills/mcp-async-skill/` から `release/claude/lazykamui/.claude/` へコピー
+   - `scripts/generate_skill.py`
+   - `scripts/mcp_async_call.py`
+   - `scripts/mcp_worker_daemon.py`
+   - `scripts/job_queue/` パッケージ一式
+   - `SKILL.md`
+   - テスト・`__pycache__` は除外
+2. **バージョン書き換え** — `pyproject.toml` と `__init__.py` の version をタグから反映
+3. **コミット＆push** — `release: update release/claude/ to v1.0.0` として main に push
+4. **タグ更新** — リリースファイルを含む状態でタグを force-update
+
+### 4. 動作確認
+
+```bash
+# pip install で確認（バージョン指定）
+pip install git+https://github.com/Yumeno/LazyKamuiCodeSkillsCreator.git@v1.0.0#subdirectory=release/claude
+
+# CLI が動くか
+generate-skill --help
+
+# バージョン確認
+python -c "import lazykamui; print(lazykamui.__version__)"
+```
+
+### 5. （任意）GitHub Releases にノートを追加
+
+```bash
+gh release create v1.0.0 --title "v1.0.0" --notes "リリースノート内容"
+```
+
+## バージョニング規則
+
+[セマンティックバージョニング](https://semver.org/lang/ja/) に従います：
+
+| 変更内容 | バージョン | 例 |
+|----------|-----------|-----|
+| 後方互換性のないAPI変更 | メジャー | v1.0.0 → v2.0.0 |
+| 後方互換性のある機能追加 | マイナー | v1.0.0 → v1.1.0 |
+| バグ修正 | パッチ | v1.0.0 → v1.0.1 |
+
+## CI ワークフローの仕組み
+
+```
+v* タグ push
+  │
+  ├─ checkout
+  ├─ タグからバージョン抽出（v1.0.0 → 1.0.0）
+  ├─ .claude/skills/ → release/claude/lazykamui/.claude/ にスクリプトをコピー
+  ├─ pyproject.toml / __init__.py のバージョンを書き換え
+  ├─ main にコミット＆push
+  └─ タグを force-update（リリースファイル込みの状態に更新）
+```
+
+タグの force-update により、`pip install ...@v1.0.0` で正しいバージョンのスクリプトが取得されます。
+
+## トラブルシューティング
+
+### CI が失敗した場合
+
+1. GitHub Actions のログを確認
+2. 修正を main に push
+3. タグを削除して再作成：
+   ```bash
+   git tag -d v1.0.0
+   git push origin :refs/tags/v1.0.0
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+### ローカルでリリースパッケージを確認したい場合
+
+```bash
+# スクリプトを手動で同期
+SRC=.claude/skills/mcp-async-skill
+DST=release/claude/lazykamui/.claude/skills/mcp-async-skill
+rm -rf $DST/scripts $DST/SKILL.md
+mkdir -p $DST/scripts/job_queue
+cp $SRC/scripts/generate_skill.py $DST/scripts/
+cp $SRC/scripts/mcp_async_call.py $DST/scripts/
+cp $SRC/scripts/mcp_worker_daemon.py $DST/scripts/
+cp $SRC/scripts/job_queue/__init__.py $DST/scripts/job_queue/
+cp $SRC/scripts/job_queue/db.py $DST/scripts/job_queue/
+cp $SRC/scripts/job_queue/dispatcher.py $DST/scripts/job_queue/
+cp $SRC/scripts/job_queue/worker.py $DST/scripts/job_queue/
+cp $SRC/scripts/job_queue/client.py $DST/scripts/job_queue/
+cp $SRC/SKILL.md $DST/
+
+# editable install でテスト
+cd release/claude
+pip install -e .
+generate-skill --help
+```
+
+> **注意**: `release/claude/lazykamui/.claude/` は `.gitignore` に含まれているため、ローカルで同期したファイルはコミットされません。CI のみがこれらのファイルをコミットします。


### PR DESCRIPTION
## Summary

- README.md のセットアップを「方法A: pip install（推奨）」と「方法B: git clone（開発者向け）」に分割
- `docs/release-process.md` にタグ push からリリースまでの手順書を新規作成

refs #7

## 変更内容

### README.md
- `pip install git+...#subdirectory=release/claude` による導入手順を追加
- `generate-skill` コマンド / `python -m lazykamui` の使用例を記載
- 従来の git clone 手順は「開発者向け」として残存

### docs/release-process.md（新規）
- バージョンタグの作成・push 手順
- CI 自動処理（スクリプト同期 → バージョン書き換え → コミット → タグ更新）の解説
- 動作確認コマンド
- トラブルシューティング（CI失敗時のタグ再作成、ローカル確認方法）

## Test plan

- [ ] README の pip install コマンドが正しいことを確認
- [ ] docs/release-process.md の手順が CI ワークフローと整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)