### PR TITLE
fix: デフォルト出力先をCWDベースに固定

### DIFF
--- a/.claude/skills/mcp-async-skill/scripts/generate_skill.py
+++ b/.claude/skills/mcp-async-skill/scripts/generate_skill.py
@@ -1305,19 +1305,8 @@ def generate_skill(
 
 
 def get_default_output_dir() -> str:
-    """Get default output directory (.claude/skills relative to cwd or script location)."""
-    # Try current working directory first
-    cwd_skills = Path.cwd() / ".claude" / "skills"
-    if cwd_skills.parent.exists():  # .claude exists
-        return str(cwd_skills)
-
-    # Fall back to script location
-    script_skills = Path(__file__).parent.parent.parent
-    if script_skills.name == "skills" and script_skills.parent.name == ".claude":
-        return str(script_skills)
-
-    # Default to cwd/.claude/skills
-    return str(cwd_skills)
+    """Get default output directory (.claude/skills relative to cwd)."""
+    return str(Path.cwd() / ".claude" / "skills")
 
 
 def generate_skills_for_servers(


### PR DESCRIPTION
## Summary

- `generate_skill.py` のデフォルト出力先が pip install 時に site-packages 内を指すバグを修正
- スクリプト位置ベースのフォールバック（L1314-1317）を削除し、常に `CWD/.claude/skills/` を返すよう簡素化

## 問題

`get_default_output_dir()` のフォールバックロジックが `Path(__file__).parent` からスキルディレクトリを探すため、pip install 環境ではスキルが `site-packages/lazykamui/.claude/skills/` に生成されてしまう。

## 修正

```python
# Before (13行)
def get_default_output_dir() -> str:
    cwd_skills = Path.cwd() / ".claude" / "skills"
    if cwd_skills.parent.exists():
        return str(cwd_skills)
    script_skills = Path(__file__).parent.parent.parent  # ← site-packages を指す
    if script_skills.name == "skills" and ...:
        return str(script_skills)
    return str(cwd_skills)

# After (2行)
def get_default_output_dir() -> str:
    return str(Path.cwd() / ".claude" / "skills")
```

出力ディレクトリは `os.makedirs(exist_ok=True)` で生成時に作成されるので、`.claude/` が存在しなくても問題なし。

## Test plan

- [x] 既存テスト 217 件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)