### PR TITLE
feat: リリース時にドキュメントのダウンロードURLを自動更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,3 +72,15 @@ jobs:
             mcp-async-skill.tar.gz \
             --title "$TAG" \
             --notes-file release-notes.md
+
+      - name: Update version in docs
+        run: |
+          TAG="${{ github.ref_name }}"
+          git checkout main
+          sed -i -E "s|releases/download/lazy-v[0-9.]+/|releases/download/${TAG}/|g" README.md docs/release-process.md
+          git diff --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md docs/release-process.md
+          git commit -m "docs: update download URLs to ${TAG}"
+          git push


### PR DESCRIPTION
## Summary

- release.yml の `build-release` ジョブ末尾に「Update version in docs」ステップを追加
- タグ push 時に README.md と docs/release-process.md 内の `releases/download/lazy-v*` URLを最新タグに自動置換
- 変更がある場合のみ bot ユーザーで main にコミット＆プッシュ（冪等性あり）

## Test plan

- [ ] マージ後 `lazy-v2.1.1` タグを push して Actions が正常に動作することを確認
- [ ] main ブランチに docs のバージョン更新コミットが追加されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)