### PR TITLE
feat: 直接実行モードを完全廃止しキューモードをデフォルトに

### DIFF
--- a/.claude/skills/mcp-async-skill/SKILL.md
+++ b/.claude/skills/mcp-async-skill/SKILL.md
@@ -267,7 +267,7 @@ Main async MCP caller with full flow automation.
 - `--config, -c`: Load endpoint from .mcp.json
 - `--save-logs`: Save request/response logs to `{output}/logs/`
 - `--save-logs-inline`: Save logs alongside output file as `{filename}_*.json`
-- `--queue-config`: Path to queue_config.json (enables queue mode with rate limiting)
+- `--queue-config`: Path to queue_config.json (auto-discovered if not specified; all execution uses queue system)
 - `--worker-url`: Worker URL (default: from queue config)
 - `--submit-only`: Submit job to queue and return `job_id` immediately
 - `--wait JOB_ID`: Check job status once and return immediately
@@ -391,12 +391,12 @@ print(result["saved_path"])  # Path to downloaded file
 
 ## Queue System (Rate Limiting)
 
-Generated skills include a local queue system that prevents overloading MCP servers when AI agents call tools in parallel.
+All execution goes through a local queue system that prevents overloading MCP servers. Direct execution mode is not available.
 
 **How it works:**
 - A local worker daemon (port 54321) accepts job submissions via HTTP and dispatches them with per-endpoint rate limiting
 - The worker starts automatically on first use and stops after idle timeout (default: 60s)
-- Rate limits are configured per-endpoint in `queue_config.json`
+- Rate limits are configured per-endpoint in `queue_config.json` (auto-discovered if `--queue-config` is not specified)
 - Multiple skills share a single worker process and queue directory (`.claude/queue/`)
 - When the worker is stopped (idle timeout), `--list`, `--stats`, and `--wait` automatically fall back to reading from SQLite (`jobs.db`), so job data remains accessible without restarting the worker
 

--- a/.claude/skills/mcp-async-skill/scripts/generate_skill.py
+++ b/.claude/skills/mcp-async-skill/scripts/generate_skill.py
@@ -398,7 +398,7 @@ def convert_tools_to_yaml_dict(tools: list[dict], mcp_config: dict = None, skill
                 "--header": "カスタムヘッダー追加 (Key:Value形式、複数可)",
                 "--save-logs": "{output}/logs/ にログ保存",
                 "--save-logs-inline": "出力ファイル横にログ保存",
-                "--queue-config": "queue_config.jsonへのパス（キューモード有効化）",
+                "--queue-config": "queue_config.jsonへのパス（未指定時は自動探索。全実行はキューシステム経由）",
                 "--submit-only": "ジョブ投入のみ（job_id即返却）",
                 "--wait JOB_ID": "ジョブ状態確認",
                 "--list": "キュー内ジョブ一覧（JSON出力）",
@@ -827,7 +827,7 @@ python .claude/skills/{skill_name}/scripts/mcp_async_call.py \\
 | `--header` | - | カスタムヘッダー追加 (`Key:Value`形式、複数可) | - |
 | `--save-logs` | - | `{{output}}/logs/` にログ保存 | 無効 |
 | `--save-logs-inline` | - | 出力ファイル横にログ保存 | 無効 |
-| `--queue-config` | - | queue_config.jsonへのパス | ラッパー自動設定 |
+| `--queue-config` | - | queue_config.jsonへのパス（未指定時は自動探索） | ラッパー自動設定 |
 | `--submit-only` | - | ジョブ投入のみ（job_id即返却） | 無効 |
 | `--wait` | - | ジョブ状態確認（JOB_ID指定） | - |
 | `--list` | - | キュー内ジョブ一覧（JSON出力） | - |

--- a/.claude/skills/mcp-async-skill/scripts/mcp_async_call.py
+++ b/.claude/skills/mcp-async-skill/scripts/mcp_async_call.py
@@ -757,13 +757,40 @@ def load_mcp_config(config_path: str) -> dict:
         return json.load(f)
 
 
+def _find_queue_config() -> str | None:
+    """Auto-discover queue_config.json by searching upward from the script.
+
+    Search order:
+      1. Script's parent directory (skill_dir/scripts/ -> skill_dir/)
+      2. Project root (directory containing .claude/)
+
+    Returns the path if found, None otherwise.
+    """
+    from mcp_worker_daemon import find_project_root
+
+    # Search from script's parent dir (typical: skill_dir/scripts/mcp_async_call.py)
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    skill_dir = os.path.dirname(script_dir)
+    candidate = os.path.join(skill_dir, "queue_config.json")
+    if os.path.exists(candidate):
+        return candidate
+
+    # Search from project root
+    project_root = find_project_root(script_dir)
+    candidate = os.path.join(project_root, "queue_config.json")
+    if os.path.exists(candidate):
+        return candidate
+
+    return None
+
+
 def resolve_worker_url(
     worker_url: str | None = None,
     queue_config_path: str | None = None,
 ) -> str | None:
     """Resolve the worker URL from explicit arg or queue config file.
 
-    Returns None if neither is provided (direct execution mode).
+    Returns the default URL if no config is available.
     """
     if worker_url:
         return worker_url
@@ -776,7 +803,8 @@ def resolve_worker_url(
     if queue_config_path:
         # Config path specified but file doesn't exist yet; use defaults
         return "http://127.0.0.1:54321"
-    return None
+    # No config at all; return default
+    return "http://127.0.0.1:54321"
 
 
 def _queue_submit_only(
@@ -1058,7 +1086,11 @@ def route_execution(
     save_logs_to_dir: bool = False,
     save_logs_inline: bool = False,
 ) -> dict:
-    """Route execution to queue system or direct MCP call."""
+    """Route execution to queue system.
+
+    All execution goes through the queue system for rate limiting.
+    Direct execution mode has been removed.
+    """
     submit_args = submit_args or {}
     headers = headers or {}
 
@@ -1066,93 +1098,64 @@ def route_execution(
     # the worker; they fall back to SQLite when the worker is unreachable.
     is_read_only = bool(list_jobs or show_stats or wait_job_id)
 
+    # Resolve worker URL (always available — defaults to http://127.0.0.1:54321)
+    url = worker_url or resolve_worker_url(None, queue_config_path)
+
     # Auto-start worker daemon only for write operations
-    needs_worker = bool(
-        (worker_url or queue_config_path) and not is_read_only
-    )
-    if needs_worker:
-        resolved_url = (
-            worker_url
-            or resolve_worker_url(None, queue_config_path)
-            or "http://127.0.0.1:54321"
-        )
-        _ensure_worker_running(resolved_url, queue_config_path)
+    if not is_read_only:
+        _ensure_worker_running(url, queue_config_path)
 
     # --list mode
     if list_jobs:
-        url = worker_url or resolve_worker_url(None, queue_config_path) or "http://127.0.0.1:54321"
         return _queue_list(url, status_filter=filter_status,
                            include_args=show_args,
                            queue_config_path=queue_config_path)
 
     # --stats mode
     if show_stats:
-        url = worker_url or resolve_worker_url(None, queue_config_path) or "http://127.0.0.1:54321"
         return _queue_stats(url, queue_config_path=queue_config_path)
 
     # --wait mode
     if wait_job_id:
-        url = worker_url or resolve_worker_url(None, queue_config_path) or "http://127.0.0.1:54321"
         return _queue_wait(url, wait_job_id, include_args=show_args,
                            queue_config_path=queue_config_path)
 
-    # Queue mode (--queue-config or --worker-url provided)
-    if worker_url or queue_config_path:
-        url = worker_url or resolve_worker_url(None, queue_config_path)
+    # Read endpoint rate limits from skill config if available
+    rate_limits = None
+    if queue_config_path and os.path.exists(queue_config_path) and endpoint:
+        try:
+            with open(queue_config_path, encoding="utf-8") as f:
+                skill_config = json.load(f)
+            ep_limits = skill_config.get("endpoint_rate_limits", {}).get(endpoint)
+            if ep_limits:
+                rate_limits = ep_limits
+        except (json.JSONDecodeError, OSError):
+            pass
 
-        # Read endpoint rate limits from skill config if available
-        rate_limits = None
-        if queue_config_path and os.path.exists(queue_config_path) and endpoint:
-            try:
-                with open(queue_config_path, encoding="utf-8") as f:
-                    skill_config = json.load(f)
-                ep_limits = skill_config.get("endpoint_rate_limits", {}).get(endpoint)
-                if ep_limits:
-                    rate_limits = ep_limits
-            except (json.JSONDecodeError, OSError):
-                pass
-
-        if submit_only:
-            return _queue_submit_only(
-                worker_url=url,
-                endpoint=endpoint,
-                submit_tool=submit_tool,
-                submit_args=submit_args,
-                status_tool=status_tool,
-                result_tool=result_tool,
-                headers=headers if headers != {"Content-Type": "application/json"} else None,
-                rate_limits=rate_limits,
-            )
-        else:
-            return _queue_blocking(
-                worker_url=url,
-                endpoint=endpoint,
-                submit_tool=submit_tool,
-                submit_args=submit_args,
-                status_tool=status_tool,
-                result_tool=result_tool,
-                headers=headers if headers != {"Content-Type": "application/json"} else None,
-                rate_limits=rate_limits,
-                poll_interval=poll_interval,
-                max_polls=max_polls,
-            )
-
-    # Direct execution mode (backward compatible)
-    return run_async_mcp_job(
-        endpoint=endpoint,
-        submit_tool=submit_tool,
-        submit_args=submit_args,
-        status_tool=status_tool,
-        result_tool=result_tool,
-        output_dir=output_dir,
-        output_file=output_file,
-        auto_filename=auto_filename,
-        poll_interval=poll_interval,
-        max_polls=max_polls,
-        headers=headers,
-        save_logs_to_dir=save_logs_to_dir,
-        save_logs_inline=save_logs_inline,
-    )
+    if submit_only:
+        return _queue_submit_only(
+            worker_url=url,
+            endpoint=endpoint,
+            submit_tool=submit_tool,
+            submit_args=submit_args,
+            status_tool=status_tool,
+            result_tool=result_tool,
+            headers=headers if headers != {"Content-Type": "application/json"} else None,
+            rate_limits=rate_limits,
+        )
+    else:
+        return _queue_blocking(
+            worker_url=url,
+            endpoint=endpoint,
+            submit_tool=submit_tool,
+            submit_args=submit_args,
+            status_tool=status_tool,
+            result_tool=result_tool,
+            headers=headers if headers != {"Content-Type": "application/json"} else None,
+            rate_limits=rate_limits,
+            poll_interval=poll_interval,
+            max_polls=max_polls,
+        )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1161,18 +1164,21 @@ def build_parser() -> argparse.ArgumentParser:
         description="Run async MCP job",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
+All execution goes through the queue system for rate limiting.
+queue_config.json is auto-discovered if --queue-config is not specified.
+
 Examples:
-  # Basic usage (directory output, auto filename)
-  python mcp_async_call.py --endpoint "..." --submit-tool "..." --output ./results/
+  # Submit only (queue_config.json auto-discovered)
+  python mcp_async_call.py --endpoint "..." --submit-tool "..." --submit-only --args '{...}'
 
-  # Queue mode: submit only
-  python mcp_async_call.py --queue-config queue_config.json --submit-only --submit-tool "..." --args '{...}'
+  # Blocking (submit + poll until done)
+  python mcp_async_call.py --endpoint "..." --submit-tool "..." --args '{...}'
 
-  # Queue mode: check job status
-  python mcp_async_call.py --queue-config queue_config.json --wait JOB_ID
-
-  # Queue mode: blocking (submit + poll until done)
+  # Explicit queue config
   python mcp_async_call.py --queue-config queue_config.json --submit-tool "..." --args '{...}'
+
+  # Check job status
+  python mcp_async_call.py --wait JOB_ID
 """
     )
     parser.add_argument("--config", "-c", help="Path to .mcp.json config file")
@@ -1193,7 +1199,7 @@ Examples:
 
     # Queue system options
     queue_group = parser.add_argument_group("Queue system")
-    queue_group.add_argument("--queue-config", help="Path to queue_config.json (enables queue mode)")
+    queue_group.add_argument("--queue-config", help="Path to queue_config.json (auto-discovered if not specified)")
     queue_group.add_argument("--worker-url", help="Worker URL (default: from queue config or http://127.0.0.1:54321)")
     queue_group.add_argument("--submit-only", action="store_true", help="Submit job and return job_id immediately")
     queue_group.add_argument("--wait", metavar="JOB_ID", help="Query job status by ID")
@@ -1239,13 +1245,11 @@ def main():
     if not args.submit_tool:
         parser.error("--submit-tool is required (unless using --wait)")
 
-    # Direct mode requires status-tool and result-tool
-    is_queue_mode = bool(args.queue_config or args.worker_url)
-    if not is_queue_mode:
-        if not args.status_tool:
-            parser.error("--status-tool is required for direct mode (use --queue-config for queue mode)")
-        if not args.result_tool:
-            parser.error("--result-tool is required for direct mode (use --queue-config for queue mode)")
+    # Auto-discover queue_config.json if not explicitly provided
+    if not args.queue_config and not args.worker_url:
+        auto_config = _find_queue_config()
+        if auto_config:
+            args.queue_config = auto_config
 
     # Load config
     endpoint = args.endpoint

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_mcp_async_call_queue.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_mcp_async_call_queue.py
@@ -99,10 +99,11 @@ class TestResolveWorkerUrl(unittest.TestCase):
         os.unlink(f.name)
         self.assertEqual(url, "http://127.0.0.1:12345")
 
-    def test_resolve_default_none(self):
+    def test_resolve_default_returns_default_url(self):
+        """No args → returns default worker URL (direct mode removed)."""
         from mcp_async_call import resolve_worker_url
         url = resolve_worker_url(worker_url=None, queue_config_path=None)
-        self.assertIsNone(url)
+        self.assertEqual(url, "http://127.0.0.1:54321")
 
 
 # ── 5-3. Routing Logic ─────────────────────────────────────────────────
@@ -110,10 +111,11 @@ class TestResolveWorkerUrl(unittest.TestCase):
 class TestRouting(unittest.TestCase):
     """Queue mode routing: direct vs submit-only vs wait vs blocking."""
 
-    def test_route_direct_mode_without_queue(self):
-        """No queue args → run_async_mcp_job is called."""
+    def test_route_without_queue_args_uses_queue_blocking(self):
+        """No queue args → queue blocking mode (direct mode removed)."""
         from mcp_async_call import route_execution
-        with mock.patch("mcp_async_call.run_async_mcp_job") as m:
+        with mock.patch("mcp_async_call._queue_blocking") as m, \
+             mock.patch("mcp_async_call._ensure_worker_running"):
             m.return_value = {"status": "completed"}
             result = route_execution(
                 worker_url=None,

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ python scripts/mcp_async_call.py \
 | `--config, -c` | .mcp.jsonからエンドポイントを読み込み |
 | `--save-logs` | `{output}/logs/` にリクエスト/レスポンスログを保存 |
 | `--save-logs-inline` | 出力ファイルと同じ場所に `{filename}_*.json` 形式でログ保存 |
-| `--queue-config` | queue_config.jsonへのパス（キューモード有効化） |
+| `--queue-config` | queue_config.jsonへのパス（未指定時は自動探索。全実行はキューシステム経由） |
 | `--worker-url` | ワーカーURL（デフォルト: queue_config.jsonから取得） |
 | `--submit-only` | ジョブをキューに投入し `job_id` を返して即終了 |
 | `--wait JOB_ID` | 指定ジョブの状態を1回確認して返却 |
@@ -427,7 +427,7 @@ print(result["saved_path"])  # ダウンロードしたファイルへのパス
 
 ## キューシステム
 
-生成されたスキルには、AIエージェントが並列にツールを呼び出した際のMCPサーバー過負荷を防ぐローカルキューシステムが含まれます。
+すべての実行はキューシステムを経由します。直接実行モードは廃止されました。`queue_config.json` は `--queue-config` 未指定時でも自動探索されます。
 
 ### 仕組み
 


### PR DESCRIPTION
## Summary

- 直接実行モード（`run_async_mcp_job` への分岐）を完全削除
- `--queue-config` 未指定時に `queue_config.json` を自動探索（スキルディレクトリ → プロジェクトルート）
- 見つからなくてもデフォルト設定（`http://127.0.0.1:54321`）でキューモード起動
- ドキュメント（README.md / SKILL.md / 生成されるSKILL.md）を更新

## 背景

テスターの LLM が `--queue-config` なしで `mcp_async_call.py` を直接実行し、レートリミットが一切効かない状態で MCP サーバーに大量リクエストを投げてしまった。直接実行モードは事故のもとなので完全廃止。

Closes #41

## Test plan

- [x] `python -m pytest .claude/skills/mcp-async-skill/scripts/tests/ -q` — 224テスト全パス
- [ ] `--queue-config` なしで実行 → キューモードで動作すること
- [ ] wrapper スクリプト経由での実行が従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)