### PR TITLE
feat(queue): per-category individual rate limits + baseline test repair (#59)

### DIFF
--- a/.claude/skills/mcp-async-skill/scripts/generate_skill.py
+++ b/.claude/skills/mcp-async-skill/scripts/generate_skill.py
@@ -981,7 +981,18 @@ def detect_id_param_name(tools: list[dict]) -> str:
 
 
 def generate_queue_config(endpoint: str) -> dict:
-    """Generate a default queue_config.json for the given endpoint."""
+    """Generate a default queue_config.json for the given endpoint.
+
+    Uses the lazy-v2.11.0 per-category schema: each of t2i/i2i/t2v/i2v has
+    its own ``max_inflight``, ``min_interval``, and ``exhaust_cooldown``.
+    Adjust these per category to match the upstream service's per-category
+    rate limits.
+    """
+    per_cat_default = {
+        "max_inflight": 1,
+        "min_interval": 1.0,
+        "exhaust_cooldown": 3600,
+    }
     return {
         "host": "127.0.0.1",
         "port": 54321,
@@ -999,9 +1010,12 @@ def generate_queue_config(endpoint: str) -> dict:
         "category_rate_limits": {
             "categories": ["t2i", "i2i", "t2v", "i2v"],
             "aliases": {"r2i": "i2i", "r2v": "i2v"},
-            "min_interval": 1.0,
-            "max_category_inflight": 1,
-            "exhaust_cooldown": 3600,
+            "limits": {
+                "t2i": dict(per_cat_default),
+                "i2i": dict(per_cat_default),
+                "t2v": dict(per_cat_default),
+                "i2v": dict(per_cat_default),
+            },
         },
     }
 

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/category_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/category_limiter.py
@@ -1,11 +1,19 @@
 # -*- coding: utf-8 -*-
 """Category-level rate limiting for MCP job queue.
 
-Manages per-category (t2i, i2i, t2v, i2v) dispatch gating:
+Manages per-category (t2i, i2i, t2v, i2v) dispatch gating with
+**per-category individual values** for inflight, min_interval, and
+429 cooldown:
+
 - Inflight control (submit concurrency per category)
 - Rolling-window cooldown after 429 responses
 - Immediate pause with detailed reason on non-429 submit errors
 - Manual pause/resume with category state reporting
+
+Each category has its own `max_inflight`, `min_interval`, `exhaust_cooldown`
+configured via the `limits` mapping. Categories or keys not in `limits`
+fall back to module-level hardcoded defaults (this is a safety net for
+config typos; the canonical schema fully populates `limits`).
 
 429 errors trigger a cooldown but do NOT auto-pause the category.
 The job is returned to pending and retried after the cooldown expires.
@@ -24,47 +32,155 @@ KNOWN_CATEGORIES: set[str] = {"t2i", "i2i", "t2v", "i2v"}
 
 DEFAULT_ALIASES: dict[str, str] = {"r2i": "i2i", "r2v": "i2v"}
 
+# Hardcoded fallback values for categories / keys missing from `limits`.
+# The canonical schema is to fully populate `limits.{cat}.{key}` for each
+# known category. These defaults exist only as a safety net for config typos
+# and for unit-test convenience.
+HARDCODED_DEFAULT_MAX_INFLIGHT: int = 1
+HARDCODED_DEFAULT_MIN_INTERVAL: float = 1.0
+HARDCODED_DEFAULT_EXHAUST_COOLDOWN: float = 3600.0
+
 
 class CategoryLimiter:
-    """Category limiter with inflight control, rolling cooldown, and error pause."""
+    """Category limiter with per-category inflight, cooldown, and pause control."""
 
     def __init__(self, config: dict | None = None):
         config = config or {}
 
-        # Build category set from config or defaults
+        # ---- Build category set + aliases ----
         cat_list = config.get("categories", None)
         if cat_list is not None:
             self._categories: set[str] = set(cat_list)
         else:
             # Legacy: extract from "limits" keys if present, else use defaults
-            limits = config.get("limits", None)
-            self._categories = set(limits.keys()) if limits else set(KNOWN_CATEGORIES)
+            limits_block = config.get("limits", None)
+            self._categories = set(limits_block.keys()) if limits_block else set(KNOWN_CATEGORIES)
 
         self._aliases: dict[str, str] = {
             **DEFAULT_ALIASES,
             **config.get("aliases", {}),
         }
 
-        # Pause state (only for non-429 errors and manual pause)
+        # ---- Per-category limits (dict) ----
+        self._max_inflight: dict[str, int] = {}
+        self._min_interval: dict[str, float] = {}
+        self._exhaust_cooldown: dict[str, float] = {}
+
+        legacy_used = self._load_limits_from_config(config)
+
+        # ---- Pause / runtime state ----
         self._paused: set[str] = set()
         self._pause_reason: dict[str, dict] = {}
-
-        # Submit interval
         self._last_submit: dict[str, float] = {}
-        self._min_interval: float = float(config.get("min_interval", 1.0))
-
-        # Inflight control (submit concurrency per category)
         self._inflight: dict[str, int] = {}
-        self._max_inflight: int = int(config.get("max_category_inflight", 1))
-
-        # Rolling-window cooldown for 429
         self._exhaust_time: dict[str, float] = {}
-        self._exhaust_cooldown: float = float(config.get("exhaust_cooldown", 3600.0))
-
-        # 429 counter (informational — does NOT trigger auto-pause)
         self._consecutive_429: dict[str, int] = {}
 
         self._lock = threading.Lock()
+
+        # v3 fix #9: deprecation warning fires once per CategoryLimiter instance
+        # (not process-globally). Multiple workers / multiple limiters each emit
+        # their own warning, which is intentional for visibility.
+        if legacy_used:
+            logger.warning(
+                "[CategoryLimiter] (instance %s) DEPRECATED: flat "
+                "`max_category_inflight` / `min_interval` / `exhaust_cooldown` "
+                "in category_rate_limits will be removed in lazy-v2.13.0 or later. "
+                "Migrate to `limits.{category}.{key}` per-category form. "
+                "See docs/category-limits.md.",
+                id(self),
+            )
+
+    # ------------------------------------------------------------------
+    # Config loading (with legacy compatibility)
+    # ------------------------------------------------------------------
+
+    def _load_limits_from_config(self, config: dict) -> bool:
+        """Populate per-category dicts from config. Returns True if legacy
+        flat schema was used (so caller can emit a deprecation warning).
+        """
+        new_limits = config.get("limits", None)
+        legacy_max = config.get("max_category_inflight", None)
+        legacy_interval = config.get("min_interval", None)
+        legacy_cooldown = config.get("exhaust_cooldown", None)
+
+        legacy_used = False
+
+        # ---- New schema: explicit per-category `limits` ----
+        if new_limits and isinstance(new_limits, dict):
+            for cat, overrides in new_limits.items():
+                if not isinstance(overrides, dict):
+                    continue
+                if "max_inflight" in overrides:
+                    self._max_inflight[cat] = int(overrides["max_inflight"])
+                if "min_interval" in overrides:
+                    self._min_interval[cat] = float(overrides["min_interval"])
+                if "exhaust_cooldown" in overrides:
+                    self._exhaust_cooldown[cat] = float(overrides["exhaust_cooldown"])
+
+        # ---- Legacy schema: flat `max_category_inflight` etc. ----
+        # Fan out the legacy scalar value to ALL configured categories that
+        # don't already have a per-category override. The new schema wins.
+        if legacy_max is not None or legacy_interval is not None or legacy_cooldown is not None:
+            legacy_used = True
+            for cat in self._categories:
+                if legacy_max is not None and cat not in self._max_inflight:
+                    self._max_inflight[cat] = int(legacy_max)
+                if legacy_interval is not None and cat not in self._min_interval:
+                    self._min_interval[cat] = float(legacy_interval)
+                if legacy_cooldown is not None and cat not in self._exhaust_cooldown:
+                    self._exhaust_cooldown[cat] = float(legacy_cooldown)
+
+        return legacy_used
+
+    # ------------------------------------------------------------------
+    # Per-category limit getters (public API)
+    # ------------------------------------------------------------------
+
+    def get_max_inflight(self, category: str | None) -> int:
+        """Return max_inflight for the category. Hardcoded default for unknown."""
+        if category is None or category not in self._categories:
+            logger.debug(
+                "[CategoryLimiter] get_max_inflight(%r): unknown category, "
+                "returning hardcoded default", category,
+            )
+            return HARDCODED_DEFAULT_MAX_INFLIGHT
+        return self._max_inflight.get(category, HARDCODED_DEFAULT_MAX_INFLIGHT)
+
+    def get_min_interval(self, category: str | None) -> float:
+        """Return min_interval for the category. Hardcoded default for unknown."""
+        if category is None or category not in self._categories:
+            logger.debug(
+                "[CategoryLimiter] get_min_interval(%r): unknown category, "
+                "returning hardcoded default", category,
+            )
+            return HARDCODED_DEFAULT_MIN_INTERVAL
+        return self._min_interval.get(category, HARDCODED_DEFAULT_MIN_INTERVAL)
+
+    def get_exhaust_cooldown(self, category: str | None) -> float:
+        """Return 429 cooldown for the category. Hardcoded default for unknown.
+
+        v3 fix M3: this replaces direct `_exhaust_cooldown` attribute access
+        (which was a scalar in lazy-v2.10.x and is now a per-category dict).
+        Callers from dispatcher / worker MUST use this getter.
+        """
+        if category is None or category not in self._categories:
+            logger.debug(
+                "[CategoryLimiter] get_exhaust_cooldown(%r): unknown category, "
+                "returning hardcoded default", category,
+            )
+            return HARDCODED_DEFAULT_EXHAUST_COOLDOWN
+        return self._exhaust_cooldown.get(category, HARDCODED_DEFAULT_EXHAUST_COOLDOWN)
+
+    def is_known_category(self, category: str | None) -> bool:
+        """Return True if `category` is one of the configured categories."""
+        if category is None:
+            return False
+        return category in self._categories
+
+    def get_categories(self) -> list[str]:
+        """Return the configured category list (sorted, deterministic)."""
+        return sorted(self._categories)
 
     # ------------------------------------------------------------------
     # Category extraction
@@ -96,30 +212,44 @@ class CategoryLimiter:
     # Public API — submit gating
     # ------------------------------------------------------------------
 
-    def can_submit(self, category: str) -> bool:
-        """Return True if *category* is not paused, has inflight slots,
-        and is not in cooldown."""
+    def can_submit(self, category: str | None) -> bool:
+        """Return True if *category* can submit now.
+
+        v3 fix #1: unknown categories return **False** so dispatcher can
+        treat them consistently with `acquire_inflight()` (which also
+        returns False). The dispatcher is expected to skip the category
+        check entirely when `extract_category()` returns None, so this
+        function returning False for unknown is only reached if the
+        caller explicitly passes an unknown category name.
+        """
         if category is None:
+            # category-less endpoints bypass category accounting in the dispatcher
             return True
         with self._lock:
+            if category not in self._categories:
+                # v3 fix #1: unknown is OUT OF SCOPE — no accounting at all.
+                return False
             if category in self._paused:
                 return False
-            if category not in self._categories:
-                return True
 
             # Enforce minimum interval between submits
             now = time.monotonic()
-            if (now - self._last_submit.get(category, 0.0)) < self._min_interval:
+            min_interval = self._min_interval.get(category, HARDCODED_DEFAULT_MIN_INTERVAL)
+            if (now - self._last_submit.get(category, 0.0)) < min_interval:
                 return False
 
             # Inflight check
-            if self._inflight.get(category, 0) >= self._max_inflight:
+            max_inflight = self._max_inflight.get(category, HARDCODED_DEFAULT_MAX_INFLIGHT)
+            if self._inflight.get(category, 0) >= max_inflight:
                 return False
 
             # Cooldown check (429 rolling window)
             exhaust_at = self._exhaust_time.get(category, 0.0)
             if exhaust_at > 0:
-                if (now - exhaust_at) < self._exhaust_cooldown:
+                cooldown = self._exhaust_cooldown.get(
+                    category, HARDCODED_DEFAULT_EXHAUST_COOLDOWN
+                )
+                if (now - exhaust_at) < cooldown:
                     return False
                 else:
                     # Cooldown expired
@@ -131,14 +261,14 @@ class CategoryLimiter:
 
             return True
 
-    def touch_submit(self, category: str):
+    def touch_submit(self, category: str | None):
         """Update last-submit timestamp (for min_interval enforcement)."""
         if category is None:
             return
         with self._lock:
             self._last_submit[category] = time.monotonic()
 
-    def record_success(self, category: str):
+    def record_success(self, category: str | None):
         """Record a successful submit — resets consecutive 429 counter."""
         if category is None:
             return
@@ -149,64 +279,118 @@ class CategoryLimiter:
     # Inflight control
     # ------------------------------------------------------------------
 
-    def acquire_inflight(self, category: str) -> bool:
-        """Try to acquire an inflight slot. Returns True if acquired."""
+    def acquire_inflight(self, category: str | None) -> bool:
+        """Try to acquire an inflight slot. Returns True if acquired.
+
+        v3 fix #1: unknown categories return **False** and do NOT create
+        inflight state. This keeps `can_submit` and `acquire_inflight`
+        consistent for unknown keys.
+        """
         if category is None:
             return False
         with self._lock:
+            if category not in self._categories:
+                # v3 fix #1: do not create inflight state for unknown
+                return False
+            max_inflight = self._max_inflight.get(category, HARDCODED_DEFAULT_MAX_INFLIGHT)
             current = self._inflight.get(category, 0)
-            if current >= self._max_inflight:
+            if current >= max_inflight:
                 return False
             self._inflight[category] = current + 1
             return True
 
-    def release_inflight(self, category: str, success: bool):
+    def release_inflight(self, category: str | None, success: bool):
         """Release an inflight slot."""
         if category is None:
             return
         with self._lock:
+            if category not in self._categories:
+                # No state to release for unknown (acquire_inflight returned False)
+                return
             self._inflight[category] = max(0, self._inflight.get(category, 0) - 1)
 
     # ------------------------------------------------------------------
     # Runtime config setters
     # ------------------------------------------------------------------
 
-    def set_max_inflight(self, value: int):
-        """Change max concurrent inflight jobs per category at runtime."""
-        with self._lock:
-            self._max_inflight = max(1, int(value))
+    def set_max_inflight(self, category: str, value: int):
+        """Change max concurrent inflight jobs for a SPECIFIC category at runtime.
 
-    def set_min_interval(self, value: float):
-        """Change minimum interval between submits at runtime."""
+        BREAKING CHANGE in lazy-v2.11.0: the previous single-arg signature
+        ``set_max_inflight(value)`` (which updated all categories at once)
+        is removed. Callers must now pass an explicit category. The worker's
+        ``PATCH /api/config`` handler is responsible for emulating the
+        legacy "apply to all" behaviour at the API layer when receiving a
+        legacy-shaped body.
+        """
         with self._lock:
-            self._min_interval = max(0.0, float(value))
+            if category not in self._categories:
+                logger.warning(
+                    "[CategoryLimiter] set_max_inflight: unknown category %r ignored",
+                    category,
+                )
+                return
+            self._max_inflight[category] = max(1, int(value))
 
-    def set_exhaust_cooldown(self, value: float):
-        """Change 429 cooldown duration at runtime."""
+    def set_min_interval(self, category: str, value: float):
+        """Change minimum interval between submits for a SPECIFIC category."""
         with self._lock:
-            self._exhaust_cooldown = max(0.0, float(value))
+            if category not in self._categories:
+                logger.warning(
+                    "[CategoryLimiter] set_min_interval: unknown category %r ignored",
+                    category,
+                )
+                return
+            self._min_interval[category] = max(0.0, float(value))
+
+    def set_exhaust_cooldown(self, category: str, value: float):
+        """Change 429 cooldown duration for a SPECIFIC category."""
+        with self._lock:
+            if category not in self._categories:
+                logger.warning(
+                    "[CategoryLimiter] set_exhaust_cooldown: unknown category %r ignored",
+                    category,
+                )
+                return
+            self._exhaust_cooldown[category] = max(0.0, float(value))
 
     def get_config(self) -> dict:
-        """Return current runtime configuration values."""
-        with self._lock:
-            return {
-                "max_inflight": self._max_inflight,
-                "min_interval": self._min_interval,
-                "exhaust_cooldown": self._exhaust_cooldown,
+        """Return current runtime configuration (per-category dicts).
+
+        New shape:
+            {
+                "limits": {
+                    "t2i": {"max_inflight": 3, "min_interval": 1.0, "exhaust_cooldown": 600},
+                    ...
+                }
             }
+        """
+        with self._lock:
+            limits = {}
+            for cat in sorted(self._categories):
+                limits[cat] = {
+                    "max_inflight": self._max_inflight.get(cat, HARDCODED_DEFAULT_MAX_INFLIGHT),
+                    "min_interval": self._min_interval.get(cat, HARDCODED_DEFAULT_MIN_INTERVAL),
+                    "exhaust_cooldown": self._exhaust_cooldown.get(
+                        cat, HARDCODED_DEFAULT_EXHAUST_COOLDOWN
+                    ),
+                }
+            return {"limits": limits}
 
     # ------------------------------------------------------------------
     # 429 handling (cooldown only — no auto-pause)
     # ------------------------------------------------------------------
 
-    def force_cooldown(self, category: str):
+    def force_cooldown(self, category: str | None):
         """Start rolling cooldown for the category (on 429)."""
         if category is None:
             return
         with self._lock:
+            if category not in self._categories:
+                return
             self._exhaust_time[category] = time.monotonic()
 
-    def record_429(self, category: str):
+    def record_429(self, category: str | None):
         """Increment consecutive 429 counter (informational only).
 
         Unlike previous versions, this does NOT auto-pause the category.
@@ -216,6 +400,8 @@ class CategoryLimiter:
         if category is None:
             return
         with self._lock:
+            if category not in self._categories:
+                return
             count = self._consecutive_429.get(category, 0) + 1
             self._consecutive_429[category] = count
             if count % 10 == 0:
@@ -231,7 +417,7 @@ class CategoryLimiter:
 
     def pause_with_reason(
         self,
-        category: str,
+        category: str | None,
         reason: str,
         status_code: int | None = None,
         error_detail: str = "",
@@ -242,6 +428,8 @@ class CategoryLimiter:
         if category is None:
             return
         with self._lock:
+            if category not in self._categories:
+                return
             self._paused.add(category)
             self._pause_reason[category] = {
                 "reason": reason,
@@ -263,6 +451,8 @@ class CategoryLimiter:
     def pause_category(self, category: str):
         """Manually pause a category. Pending jobs stay in queue."""
         with self._lock:
+            if category not in self._categories:
+                return
             self._paused.add(category)
             self._pause_reason[category] = {
                 "reason": "manual",
@@ -272,19 +462,25 @@ class CategoryLimiter:
     def resume_category(self, category: str):
         """Remove pause, clear reason and consecutive 429 counter."""
         with self._lock:
+            if category not in self._categories:
+                return
             self._paused.discard(category)
             self._pause_reason.pop(category, None)
             self._consecutive_429.pop(category, None)
             # Also clear cooldown so dispatch resumes immediately
             self._exhaust_time.pop(category, None)
 
-    def is_paused(self, category: str) -> bool:
+    def is_paused(self, category: str | None) -> bool:
         """Return True if *category* is paused."""
+        if category is None:
+            return False
         with self._lock:
             return category in self._paused
 
-    def get_pause_reason(self, category: str) -> dict | None:
+    def get_pause_reason(self, category: str | None) -> dict | None:
         """Return pause reason dict, or None if not paused."""
+        if category is None:
+            return None
         with self._lock:
             return self._pause_reason.get(category)
 
@@ -293,20 +489,33 @@ class CategoryLimiter:
     # ------------------------------------------------------------------
 
     def get_all_status(self) -> dict:
-        """Return status for all configured categories."""
+        """Return status for all configured categories.
+
+        Each category's `max_inflight` reflects its per-category value
+        (v3 change: was a single shared value in lazy-v2.10.x).
+        """
         with self._lock:
             now = time.monotonic()
             result = {}
             for cat in sorted(self._categories):
                 exhaust_at = self._exhaust_time.get(cat, 0.0)
+                cooldown = self._exhaust_cooldown.get(
+                    cat, HARDCODED_DEFAULT_EXHAUST_COOLDOWN
+                )
                 cooldown_remaining = max(
-                    0.0, self._exhaust_cooldown - (now - exhaust_at)
+                    0.0, cooldown - (now - exhaust_at)
                 ) if exhaust_at > 0 else 0.0
 
                 entry: dict = {
                     "paused": cat in self._paused,
                     "inflight": self._inflight.get(cat, 0),
-                    "max_inflight": self._max_inflight,
+                    "max_inflight": self._max_inflight.get(
+                        cat, HARDCODED_DEFAULT_MAX_INFLIGHT
+                    ),
+                    "min_interval": self._min_interval.get(
+                        cat, HARDCODED_DEFAULT_MIN_INTERVAL
+                    ),
+                    "exhaust_cooldown": cooldown,
                     "consecutive_429": self._consecutive_429.get(cat, 0),
                     "cooldown_remaining_s": round(cooldown_remaining, 1),
                 }

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/db.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/db.py
@@ -238,14 +238,15 @@ class JobStore:
             List of job dicts ordered by updated_at ascending (oldest first).
         """
         with self._lock:
+            now_iso = _utc_now_iso()
             cur = self.conn.execute(
                 """
                 SELECT * FROM jobs
                 WHERE status = 'polling'
-                  AND (julianday('now') - julianday(REPLACE(updated_at, 'Z', ''))) * 86400.0 >= ?
+                  AND (julianday(?) - julianday(updated_at)) * 86400.0 >= ?
                 ORDER BY updated_at ASC
                 """,
-                (timeout_seconds,),
+                (now_iso, timeout_seconds),
             )
             return [dict(row) for row in cur.fetchall()]
 
@@ -274,15 +275,25 @@ class JobStore:
 
         Returns:
             Number of deleted jobs.
+
+        Note:
+            Both `now` and `updated_at` are computed in Python via
+            ``_utc_now_iso()`` so they share the same microsecond-precision
+            wall-clock source. Mixing SQLite's ``julianday('now')`` (which
+            is second-precision and lags behind ``_utc_now_iso()`` by a few
+            milliseconds) with Python-generated microsecond timestamps used
+            to make ``retention_seconds=0`` purges silently drop nothing
+            (regression introduced in commit ``95ebebb``).
         """
         with self._lock:
+            now_iso = _utc_now_iso()
             cur = self.conn.execute(
                 """
                 DELETE FROM jobs
                 WHERE status IN ('completed', 'failed')
-                  AND (julianday('now') - julianday(updated_at)) * 86400.0 >= ?
+                  AND (julianday(?) - julianday(updated_at)) * 86400.0 >= ?
                 """,
-                (retention_seconds,),
+                (now_iso, retention_seconds),
             )
             self.conn.commit()
             return cur.rowcount

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/dispatcher.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/dispatcher.py
@@ -303,10 +303,12 @@ class Dispatcher:
                 if category:
                     self.category_limiter.force_cooldown(category)
                     self.category_limiter.record_429(category)
-                # Always set endpoint-level cooldown (covers unknown categories)
+                # Always set endpoint-level cooldown (covers unknown categories).
+                # v3 fix M3: use the public per-category getter — for unknown
+                # categories this returns the hardcoded default cooldown.
                 self.pause_endpoint(
                     job["endpoint"],
-                    self.category_limiter._exhaust_cooldown,
+                    self.category_limiter.get_exhaust_cooldown(category),
                 )
                 self.store.update_status(
                     job["id"], "pending",

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
@@ -158,9 +158,27 @@ class _RequestHandler(BaseHTTPRequestHandler):
             return
 
         if self.path == "/api/config":
+            # New schema: cat_cfg = {"limits": {"t2i": {...}, ...}}
             cat_cfg = app.dispatcher.category_limiter.get_config()
+
+            # v3 fix #8: include legacy compatibility keys at the top level of
+            # the `category` object so lazy-v2.10.x dashboard's read path
+            # (`cfg.category.max_inflight` etc.) keeps showing reasonable
+            # values instead of going blank. The first category's value is
+            # used. These keys will be removed in lazy-v2.13.0 or later.
+            limits = cat_cfg.get("limits", {})
+            first_cat_key = next(iter(sorted(limits.keys())), None)
+            legacy_compat = {}
+            if first_cat_key is not None:
+                first_cat = limits[first_cat_key]
+                legacy_compat = {
+                    "max_inflight": first_cat.get("max_inflight"),
+                    "min_interval": first_cat.get("min_interval"),
+                    "exhaust_cooldown": first_cat.get("exhaust_cooldown"),
+                }
+
             self._send_json(200, {
-                "category": cat_cfg,
+                "category": {**cat_cfg, **legacy_compat},
                 "endpoint": {
                     "default_max_concurrent": app.dispatcher.config.default_max_concurrent,
                     "default_min_interval": app.dispatcher.config.default_min_interval,
@@ -351,23 +369,88 @@ class _RequestHandler(BaseHTTPRequestHandler):
             requires_restart = []
             limiter = app.dispatcher.category_limiter
 
-            # Category settings
+            # Category settings — three accepted shapes:
+            #   1. New per-category form (preferred):
+            #      {"category": {"limits": {"t2v": {"max_inflight": 1, ...}}}}
+            #   2. Legacy flat form (lazy-v2.10.x compat — apply to ALL categories):
+            #      {"category": {"max_inflight": 1, "exhaust_cooldown": 1800}}
+            #   3. Both — new form takes precedence per category, legacy form
+            #      fills in any category not covered by `limits`.
             cat = body.get("category", {})
-            for key, setter, vtype, vmin in [
+
+            _CAT_KEY_SPEC = [
                 ("max_inflight", limiter.set_max_inflight, int, 1),
                 ("min_interval", limiter.set_min_interval, float, 0),
                 ("exhaust_cooldown", limiter.set_exhaust_cooldown, float, 0),
-            ]:
-                if key in cat:
+            ]
+
+            # ---- New form: category.limits.{cat}.{key} ----
+            # v3 fix M1: distinguish "key absent" from "explicit null".
+            # An explicit null (or any non-dict) is rejected — silently
+            # ignoring it could mask a config typo.
+            limits_block = None
+            if "limits" in cat:
+                limits_block = cat["limits"]
+                if not isinstance(limits_block, dict):
+                    rejected["category.limits"] = (
+                        f"must be object (got {type(limits_block).__name__})"
+                    )
+                    limits_block = None
+
+            covered_categories: set[str] = set()
+            if limits_block is not None:
+                for cat_name, overrides in limits_block.items():
+                    if not isinstance(overrides, dict):
+                        rejected[f"category.limits.{cat_name}"] = "must be object"
+                        continue
+                    if not limiter.is_known_category(cat_name):
+                        rejected[f"category.limits.{cat_name}"] = "unknown category"
+                        continue
+                    covered_categories.add(cat_name)
+                    for key, setter, vtype, vmin in _CAT_KEY_SPEC:
+                        if key not in overrides:
+                            continue
+                        v = overrides[key]
+                        try:
+                            v = vtype(v)
+                            if v < vmin:
+                                raise ValueError
+                            setter(cat_name, v)
+                            applied[f"category.limits.{cat_name}.{key}"] = v
+                        except (ValueError, TypeError):
+                            rejected[f"category.limits.{cat_name}.{key}"] = (
+                                f"must be {vtype.__name__} >= {vmin}"
+                            )
+
+            # ---- Legacy flat form: apply to all configured categories ----
+            # v3 fix #8: a legacy PATCH from a lazy-v2.10.x dashboard updates
+            # ALL categories at once. Any category already covered by the new
+            # `limits` block in the same request is skipped (new form wins).
+            legacy_keys_present = [k for (k, _, _, _) in _CAT_KEY_SPEC if k in cat]
+            if legacy_keys_present:
+                applied["_legacy_warning"] = (
+                    "Received legacy flat category.{key} form; applied to all "
+                    "categories not covered by category.limits in this request. "
+                    "Migrate to category.limits.{cat}.{key} per-category form."
+                )
+                for key, setter, vtype, vmin in _CAT_KEY_SPEC:
+                    if key not in cat:
+                        continue
                     v = cat[key]
                     try:
                         v = vtype(v)
                         if v < vmin:
                             raise ValueError
-                        setter(v)
-                        applied[f"category.{key}"] = v
                     except (ValueError, TypeError):
                         rejected[f"category.{key}"] = f"must be {vtype.__name__} >= {vmin}"
+                        continue
+                    affected = []
+                    for cat_name in limiter.get_categories():
+                        if cat_name in covered_categories:
+                            continue
+                        setter(cat_name, v)
+                        affected.append(cat_name)
+                    applied[f"category.{key}"] = {"value": v, "affected": affected}
 
             # Endpoint defaults
             ep = body.get("endpoint", {})

--- a/.claude/skills/mcp-async-skill/scripts/queue_config.example.json
+++ b/.claude/skills/mcp-async-skill/scripts/queue_config.example.json
@@ -15,5 +15,15 @@
       "max_concurrent_jobs": 5,
       "min_interval_seconds": 0.5
     }
+  },
+  "category_rate_limits": {
+    "categories": ["t2i", "i2i", "t2v", "i2v"],
+    "aliases": {"r2i": "i2i", "r2v": "i2v"},
+    "limits": {
+      "t2i": {"max_inflight": 3, "min_interval": 1.0, "exhaust_cooldown": 600},
+      "i2i": {"max_inflight": 2, "min_interval": 1.0, "exhaust_cooldown": 3600},
+      "t2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 1800},
+      "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
+    }
   }
 }

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_category_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_category_limiter.py
@@ -1,0 +1,462 @@
+# -*- coding: utf-8 -*-
+"""Tests for ``CategoryLimiter`` per-category rate limiting (#59).
+
+Covers:
+
+* New ``limits.{cat}.{key}`` schema and per-category isolation.
+* Hardcoded fallback when a category or key is missing from the config.
+* Legacy flat schema (``max_category_inflight`` / ``min_interval`` /
+  ``exhaust_cooldown``) — fanned out to all configured categories with
+  a one-shot deprecation warning per ``CategoryLimiter`` instance.
+* Unknown category: ``can_submit`` and ``acquire_inflight`` both return
+  ``False`` and create no inflight state. The two getters agree on
+  unknown keys so the dispatcher sees a consistent answer.
+* Concurrency: ``acquire_inflight`` never overshoots ``max_inflight``
+  even under heavy thread contention.
+* ``get_all_status`` reflects per-category cooldown / max_inflight values.
+* Public API: ``is_known_category``, ``get_categories``, and the
+  required ``cat`` argument on ``set_*`` setters.
+
+Spec context: per-category isolation lets the dispatcher mirror the
+upstream MCP service's per-category rolling-window rate limits.
+``set_max_inflight(cat, value)`` is the supported runtime mutation; the
+single-arg legacy form is gone — the worker's PATCH handler emulates
+"apply to all" at the API layer instead.
+"""
+import logging
+import os
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from job_queue.category_limiter import (  # noqa: E402
+    CategoryLimiter,
+    HARDCODED_DEFAULT_EXHAUST_COOLDOWN,
+    HARDCODED_DEFAULT_MAX_INFLIGHT,
+    HARDCODED_DEFAULT_MIN_INTERVAL,
+    KNOWN_CATEGORIES,
+)
+
+
+def _make_limiter(**overrides) -> CategoryLimiter:
+    """Build a CategoryLimiter with sane per-category defaults for tests.
+
+    Each test can override individual categories via ``overrides``.
+    """
+    base_limits = {
+        "t2i": {"max_inflight": 3, "min_interval": 0.0, "exhaust_cooldown": 60},
+        "i2i": {"max_inflight": 2, "min_interval": 0.0, "exhaust_cooldown": 120},
+        "t2v": {"max_inflight": 1, "min_interval": 0.0, "exhaust_cooldown": 1800},
+        "i2v": {"max_inflight": 1, "min_interval": 0.0, "exhaust_cooldown": 3600},
+    }
+    for cat, vals in overrides.items():
+        base_limits.setdefault(cat, {}).update(vals)
+
+    return CategoryLimiter({
+        "categories": list(base_limits.keys()),
+        "limits": base_limits,
+    })
+
+
+class TestPerCategoryIndependentValues(unittest.TestCase):
+    """Each category's max_inflight / min_interval / exhaust_cooldown is independent."""
+
+    def test_max_inflight_per_category(self):
+        lim = _make_limiter()
+        self.assertEqual(lim.get_max_inflight("t2i"), 3)
+        self.assertEqual(lim.get_max_inflight("i2i"), 2)
+        self.assertEqual(lim.get_max_inflight("t2v"), 1)
+        self.assertEqual(lim.get_max_inflight("i2v"), 1)
+
+    def test_exhaust_cooldown_per_category(self):
+        lim = _make_limiter()
+        self.assertEqual(lim.get_exhaust_cooldown("t2i"), 60)
+        self.assertEqual(lim.get_exhaust_cooldown("t2v"), 1800)
+        self.assertEqual(lim.get_exhaust_cooldown("i2v"), 3600)
+
+    def test_min_interval_per_category(self):
+        lim = CategoryLimiter({
+            "categories": ["t2i", "t2v"],
+            "limits": {
+                "t2i": {"max_inflight": 1, "min_interval": 0.5, "exhaust_cooldown": 60},
+                "t2v": {"max_inflight": 1, "min_interval": 5.0, "exhaust_cooldown": 60},
+            },
+        })
+        self.assertEqual(lim.get_min_interval("t2i"), 0.5)
+        self.assertEqual(lim.get_min_interval("t2v"), 5.0)
+
+    def test_inflight_per_category_does_not_leak(self):
+        """Acquiring inflight on t2i must not block i2i, even under
+        contention on either category."""
+        lim = _make_limiter()
+        # Saturate t2i (max_inflight=3)
+        self.assertTrue(lim.acquire_inflight("t2i"))
+        self.assertTrue(lim.acquire_inflight("t2i"))
+        self.assertTrue(lim.acquire_inflight("t2i"))
+        self.assertFalse(lim.acquire_inflight("t2i"))  # full
+        # i2i (max_inflight=2) is unaffected
+        self.assertTrue(lim.acquire_inflight("i2i"))
+        self.assertTrue(lim.acquire_inflight("i2i"))
+        self.assertFalse(lim.acquire_inflight("i2i"))  # i2i now full
+        # t2v (max_inflight=1) is also unaffected
+        self.assertTrue(lim.acquire_inflight("t2v"))
+        self.assertFalse(lim.acquire_inflight("t2v"))
+
+
+class TestHardcodedFallback(unittest.TestCase):
+    """Categories or keys missing from `limits` fall back to module defaults."""
+
+    def test_missing_category_returns_hardcoded_defaults(self):
+        # Configure t2i only; t2v / i2v are in `categories` but not in `limits`
+        lim = CategoryLimiter({
+            "categories": ["t2i", "t2v", "i2v"],
+            "limits": {"t2i": {"max_inflight": 5, "min_interval": 0.5, "exhaust_cooldown": 60}},
+        })
+        self.assertEqual(lim.get_max_inflight("t2v"), HARDCODED_DEFAULT_MAX_INFLIGHT)
+        self.assertEqual(lim.get_min_interval("t2v"), HARDCODED_DEFAULT_MIN_INTERVAL)
+        self.assertEqual(lim.get_exhaust_cooldown("t2v"), HARDCODED_DEFAULT_EXHAUST_COOLDOWN)
+        # The configured one is unaffected
+        self.assertEqual(lim.get_max_inflight("t2i"), 5)
+
+    def test_missing_key_within_category_falls_back(self):
+        lim = CategoryLimiter({
+            "categories": ["t2i"],
+            # Only max_inflight is set; min_interval / exhaust_cooldown missing
+            "limits": {"t2i": {"max_inflight": 7}},
+        })
+        self.assertEqual(lim.get_max_inflight("t2i"), 7)
+        self.assertEqual(lim.get_min_interval("t2i"), HARDCODED_DEFAULT_MIN_INTERVAL)
+        self.assertEqual(lim.get_exhaust_cooldown("t2i"), HARDCODED_DEFAULT_EXHAUST_COOLDOWN)
+
+
+class TestLegacySchemaCompat(unittest.TestCase):
+    """Legacy flat ``max_category_inflight`` etc. are fanned out to all
+    configured categories, with a one-shot deprecation warning per
+    CategoryLimiter instance."""
+
+    def test_legacy_flat_values_apply_to_all_categories(self):
+        lim = CategoryLimiter({
+            "categories": ["t2i", "i2i", "t2v", "i2v"],
+            "max_category_inflight": 4,
+            "min_interval": 2.5,
+            "exhaust_cooldown": 1234,
+        })
+        for cat in ["t2i", "i2i", "t2v", "i2v"]:
+            self.assertEqual(lim.get_max_inflight(cat), 4)
+            self.assertEqual(lim.get_min_interval(cat), 2.5)
+            self.assertEqual(lim.get_exhaust_cooldown(cat), 1234)
+
+    def test_new_form_wins_over_legacy_per_category(self):
+        """When both shapes are present, ``limits.{cat}`` overrides the legacy
+        flat value for that key only."""
+        lim = CategoryLimiter({
+            "categories": ["t2i", "i2i"],
+            "limits": {"t2i": {"max_inflight": 9}},
+            "max_category_inflight": 1,
+            "exhaust_cooldown": 500,
+        })
+        # t2i's max_inflight overridden by new form, but exhaust_cooldown
+        # falls through to legacy
+        self.assertEqual(lim.get_max_inflight("t2i"), 9)
+        self.assertEqual(lim.get_exhaust_cooldown("t2i"), 500)
+        # i2i has no new-form override; both come from legacy
+        self.assertEqual(lim.get_max_inflight("i2i"), 1)
+        self.assertEqual(lim.get_exhaust_cooldown("i2i"), 500)
+
+    def test_legacy_emits_deprecation_warning_once_per_instance(self):
+        """The deprecation log fires exactly once per CategoryLimiter
+        instance, never globally. Two instances → two warnings."""
+        with self.assertLogs("job_queue.category_limiter", level="WARNING") as cm1:
+            CategoryLimiter({
+                "categories": ["t2i"],
+                "max_category_inflight": 2,
+            })
+        deprecated_logs_1 = [m for m in cm1.output if "DEPRECATED" in m]
+        self.assertEqual(len(deprecated_logs_1), 1,
+                         f"Expected 1 deprecation warning, got: {cm1.output}")
+
+        with self.assertLogs("job_queue.category_limiter", level="WARNING") as cm2:
+            CategoryLimiter({
+                "categories": ["t2i"],
+                "max_category_inflight": 2,
+            })
+        deprecated_logs_2 = [m for m in cm2.output if "DEPRECATED" in m]
+        self.assertEqual(len(deprecated_logs_2), 1,
+                         "New instance must emit its own deprecation warning")
+
+    def test_new_only_schema_does_not_warn(self):
+        """No legacy keys → no deprecation warning."""
+        # assertNoLogs requires Python 3.10+, fall back to manual check.
+        logger = logging.getLogger("job_queue.category_limiter")
+        records: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = _Capture(level=logging.WARNING)
+        logger.addHandler(handler)
+        try:
+            CategoryLimiter({
+                "categories": ["t2i"],
+                "limits": {"t2i": {"max_inflight": 2, "min_interval": 0.5,
+                                   "exhaust_cooldown": 60}},
+            })
+        finally:
+            logger.removeHandler(handler)
+
+        self.assertFalse(
+            any("DEPRECATED" in r.getMessage() for r in records),
+            "New-only schema must not emit deprecation warning",
+        )
+
+
+class TestUnknownCategoryFalse(unittest.TestCase):
+    """Unknown category: can_submit and acquire_inflight both return False
+    and create no inflight state (PR #59 fix #1)."""
+
+    def test_acquire_inflight_unknown_returns_false(self):
+        lim = _make_limiter()
+        self.assertFalse(lim.acquire_inflight("unknown_cat"))
+        # No state created
+        self.assertNotIn("unknown_cat", lim._inflight)
+
+    def test_can_submit_unknown_returns_false(self):
+        lim = _make_limiter()
+        self.assertFalse(lim.can_submit("unknown_cat"))
+
+    def test_can_submit_and_acquire_inflight_consistent_for_unknown(self):
+        """Both must agree on unknown — dispatcher relies on this."""
+        lim = _make_limiter()
+        self.assertEqual(
+            lim.can_submit("unknown_cat"),
+            lim.acquire_inflight("unknown_cat"),
+        )
+
+    def test_release_inflight_unknown_is_noop(self):
+        """Releasing inflight on an unknown category does nothing
+        (acquire returned False, so there's nothing to release)."""
+        lim = _make_limiter()
+        # Should not raise; should not create state
+        lim.release_inflight("unknown_cat", success=True)
+        self.assertNotIn("unknown_cat", lim._inflight)
+
+    def test_force_cooldown_unknown_is_noop(self):
+        lim = _make_limiter()
+        lim.force_cooldown("unknown_cat")
+        self.assertNotIn("unknown_cat", lim._exhaust_time)
+
+    def test_pause_with_reason_unknown_is_noop(self):
+        lim = _make_limiter()
+        lim.pause_with_reason("unknown_cat", "test", status_code=500)
+        self.assertFalse(lim.is_paused("unknown_cat"))
+
+    def test_unknown_category_getters_return_hardcoded_defaults(self):
+        lim = _make_limiter()
+        self.assertEqual(lim.get_max_inflight("unknown"),
+                         HARDCODED_DEFAULT_MAX_INFLIGHT)
+        self.assertEqual(lim.get_min_interval("unknown"),
+                         HARDCODED_DEFAULT_MIN_INTERVAL)
+        self.assertEqual(lim.get_exhaust_cooldown("unknown"),
+                         HARDCODED_DEFAULT_EXHAUST_COOLDOWN)
+
+
+class TestNoneCategory(unittest.TestCase):
+    """Category=None means "endpoint without a recognised category" — the
+    dispatcher passes it through, and the limiter must not block it
+    nor create state."""
+
+    def test_can_submit_none_returns_true(self):
+        # category-less endpoints should be allowed to dispatch
+        lim = _make_limiter()
+        self.assertTrue(lim.can_submit(None))
+
+    def test_acquire_inflight_none_returns_false(self):
+        # but no inflight slot is created for category=None
+        lim = _make_limiter()
+        self.assertFalse(lim.acquire_inflight(None))
+
+    def test_is_paused_none_returns_false(self):
+        lim = _make_limiter()
+        self.assertFalse(lim.is_paused(None))
+
+
+class TestConcurrentAcquireInflight(unittest.TestCase):
+    """``acquire_inflight`` must not overshoot ``max_inflight`` even under
+    heavy thread contention."""
+
+    def test_concurrent_acquire_does_not_exceed_max_inflight(self):
+        lim = CategoryLimiter({
+            "categories": ["t2i"],
+            "limits": {"t2i": {"max_inflight": 5, "min_interval": 0.0,
+                               "exhaust_cooldown": 60}},
+        })
+
+        N_THREADS = 50
+        successes: list[bool] = []
+        successes_lock = threading.Lock()
+
+        def worker():
+            ok = lim.acquire_inflight("t2i")
+            with successes_lock:
+                successes.append(ok)
+
+        threads = [threading.Thread(target=worker) for _ in range(N_THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Exactly max_inflight (5) acquires should have succeeded.
+        n_acquired = sum(1 for s in successes if s)
+        self.assertEqual(n_acquired, 5,
+                         f"Expected exactly 5 acquires, got {n_acquired}")
+        # And the internal counter must agree
+        self.assertEqual(lim._inflight.get("t2i"), 5)
+
+
+class TestPerCategoryCooldownInGetAllStatus(unittest.TestCase):
+    """``get_all_status`` reflects per-category cooldown values, not a
+    single shared scalar."""
+
+    def test_status_reports_per_category_cooldown_and_max_inflight(self):
+        lim = _make_limiter()
+        status = lim.get_all_status()
+
+        self.assertEqual(status["t2i"]["max_inflight"], 3)
+        self.assertEqual(status["i2i"]["max_inflight"], 2)
+        self.assertEqual(status["t2v"]["max_inflight"], 1)
+
+        self.assertEqual(status["t2i"]["exhaust_cooldown"], 60)
+        self.assertEqual(status["t2v"]["exhaust_cooldown"], 1800)
+        self.assertEqual(status["i2v"]["exhaust_cooldown"], 3600)
+
+    def test_cooldown_remaining_uses_per_category_cooldown(self):
+        """After ``force_cooldown('t2v')``, only t2v shows non-zero
+        remaining cooldown, and it's bounded by t2v's per-category value."""
+        lim = _make_limiter()
+        lim.force_cooldown("t2v")
+        status = lim.get_all_status()
+
+        # t2v has cooldown=1800 → remaining ≈ 1800
+        self.assertGreater(status["t2v"]["cooldown_remaining_s"], 1700)
+        self.assertLessEqual(status["t2v"]["cooldown_remaining_s"], 1800)
+        # Other categories untouched
+        self.assertEqual(status["t2i"]["cooldown_remaining_s"], 0)
+        self.assertEqual(status["i2i"]["cooldown_remaining_s"], 0)
+        self.assertEqual(status["i2v"]["cooldown_remaining_s"], 0)
+
+
+class TestPublicCategoryAPI(unittest.TestCase):
+    """``is_known_category`` and ``get_categories`` replace the old habit of
+    poking ``_categories`` directly from outside the class."""
+
+    def test_is_known_category(self):
+        lim = _make_limiter()
+        self.assertTrue(lim.is_known_category("t2i"))
+        self.assertTrue(lim.is_known_category("t2v"))
+        self.assertFalse(lim.is_known_category("unknown"))
+        self.assertFalse(lim.is_known_category(None))
+
+    def test_get_categories_returns_sorted_deterministic(self):
+        lim = _make_limiter()
+        cats = lim.get_categories()
+        self.assertEqual(cats, ["i2i", "i2v", "t2i", "t2v"])
+        # Mutating the returned list must not affect internal state
+        cats.append("foo")
+        self.assertEqual(lim.get_categories(), ["i2i", "i2v", "t2i", "t2v"])
+
+
+class TestSetterCategoryRequired(unittest.TestCase):
+    """``set_max_inflight`` / ``set_min_interval`` / ``set_exhaust_cooldown``
+    take a category argument (breaking change vs lazy-v2.10.x)."""
+
+    def test_set_max_inflight_updates_only_target_category(self):
+        lim = _make_limiter()
+        lim.set_max_inflight("t2v", 7)
+        self.assertEqual(lim.get_max_inflight("t2v"), 7)
+        # Untouched
+        self.assertEqual(lim.get_max_inflight("t2i"), 3)
+        self.assertEqual(lim.get_max_inflight("i2v"), 1)
+
+    def test_set_min_interval_updates_only_target_category(self):
+        lim = _make_limiter()
+        lim.set_min_interval("t2i", 4.0)
+        self.assertEqual(lim.get_min_interval("t2i"), 4.0)
+        self.assertEqual(lim.get_min_interval("t2v"), 0.0)
+
+    def test_set_exhaust_cooldown_updates_only_target_category(self):
+        lim = _make_limiter()
+        lim.set_exhaust_cooldown("i2v", 7200)
+        self.assertEqual(lim.get_exhaust_cooldown("i2v"), 7200)
+        self.assertEqual(lim.get_exhaust_cooldown("t2v"), 1800)
+
+    def test_set_unknown_category_warns_and_is_ignored(self):
+        lim = _make_limiter()
+        with self.assertLogs("job_queue.category_limiter", level="WARNING") as cm:
+            lim.set_max_inflight("foobar", 99)
+        self.assertTrue(any("unknown category" in m for m in cm.output))
+        # State unchanged
+        self.assertNotIn("foobar", lim._max_inflight)
+
+
+class TestKnownCategoriesConstant(unittest.TestCase):
+    """Sanity check on the module-level KNOWN_CATEGORIES constant."""
+
+    def test_known_categories_contains_t2i_i2i_t2v_i2v(self):
+        self.assertEqual(KNOWN_CATEGORIES, {"t2i", "i2i", "t2v", "i2v"})
+
+    def test_default_categories_when_no_config_given(self):
+        """A bare ``CategoryLimiter()`` falls back to KNOWN_CATEGORIES."""
+        lim = CategoryLimiter()
+        self.assertEqual(set(lim.get_categories()), KNOWN_CATEGORIES)
+
+
+class TestExtractCategory(unittest.TestCase):
+    """``extract_category`` derives the canonical category from an MCP
+    endpoint URL, applying alias resolution (r2i → i2i, r2v → i2v)."""
+
+    def test_extracts_t2i(self):
+        lim = _make_limiter()
+        self.assertEqual(
+            lim.extract_category("https://kamui-code.ai/t2i/fal/flux-lora"),
+            "t2i",
+        )
+
+    def test_extracts_t2v(self):
+        lim = _make_limiter()
+        self.assertEqual(
+            lim.extract_category("https://kamui-code.ai/t2v/fal/veo3"),
+            "t2v",
+        )
+
+    def test_aliases_r2i_to_i2i(self):
+        lim = _make_limiter()
+        self.assertEqual(
+            lim.extract_category("https://kamui-code.ai/r2i/fal/refer"),
+            "i2i",
+        )
+
+    def test_aliases_r2v_to_i2v(self):
+        lim = _make_limiter()
+        self.assertEqual(
+            lim.extract_category("https://kamui-code.ai/r2v/fal/refer-video"),
+            "i2v",
+        )
+
+    def test_unknown_path_returns_none(self):
+        lim = _make_limiter()
+        self.assertIsNone(
+            lim.extract_category("https://example.com/foobar/something"),
+        )
+
+    def test_empty_path_returns_none(self):
+        lim = _make_limiter()
+        self.assertIsNone(lim.extract_category("https://example.com"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_db.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_db.py
@@ -462,6 +462,92 @@ class TestPurgeOldJobs(unittest.TestCase):
         self.assertIsNotNone(self.store.get_job(jid4))
 
 
+class TestLegacyTimestampCompat(unittest.TestCase):
+    """Pre-95ebebb DB rows used SQL-side ``strftime('%Y-%m-%dT%H:%M:%f', 'now')``
+    which produces NO trailing ``Z``. Post-95ebebb rows go through Python's
+    ``_utc_now_iso()`` and DO carry ``Z``. ``purge_old_jobs`` and
+    ``get_stale_polling`` must accept BOTH formats so that a worker that
+    upgrades over an existing DB doesn't suddenly start failing to purge
+    or detect stale jobs on its old rows.
+
+    Regression context: ``purge_old_jobs`` previously mixed
+    ``julianday('now')`` (second precision) with Python's
+    microsecond-precision timestamps, and ``get_stale_polling`` used
+    ``REPLACE(updated_at, 'Z', '')`` to strip the suffix. PR #59
+    rewrote both to pass the Python-side ``_utc_now_iso()`` as a bind
+    parameter. SQLite's ``julianday`` itself accepts the ``Z`` form
+    natively, so legacy rows without the suffix continue to parse too.
+    These tests pin both shapes down explicitly.
+    """
+
+    def setUp(self):
+        self.store = db.JobStore(":memory:")
+
+    def _insert_with_raw_updated_at(self, jid: str, status: str,
+                                    updated_at: str):
+        """Force a specific updated_at value into the DB, simulating a
+        row written by an older worker version."""
+        with self.store._lock:
+            self.store.conn.execute(
+                "UPDATE jobs SET status = ?, updated_at = ? WHERE id = ?",
+                (status, updated_at, jid),
+            )
+            self.store.conn.commit()
+
+    def test_purge_handles_legacy_no_z_timestamp(self):
+        """A legacy row without a Z suffix must still be purged when its
+        age exceeds retention_seconds."""
+        jid = self.store.insert_job(
+            endpoint="http://a:8000", submit_tool="g", args="{}",
+        )
+        # Pre-95ebebb shape: no Z, written by SQL strftime
+        self._insert_with_raw_updated_at(jid, "completed",
+                                         "2020-01-01T00:00:00.000")
+
+        count = self.store.purge_old_jobs(retention_seconds=60)
+        self.assertEqual(count, 1)
+        self.assertIsNone(self.store.get_job(jid))
+
+    def test_purge_handles_post_95ebebb_z_timestamp(self):
+        """A modern row WITH a Z suffix must also be purged when old."""
+        jid = self.store.insert_job(
+            endpoint="http://a:8000", submit_tool="g", args="{}",
+        )
+        # Post-95ebebb shape: trailing Z
+        self._insert_with_raw_updated_at(jid, "completed",
+                                         "2020-01-01T00:00:00.000000Z")
+
+        count = self.store.purge_old_jobs(retention_seconds=60)
+        self.assertEqual(count, 1)
+        self.assertIsNone(self.store.get_job(jid))
+
+    def test_get_stale_polling_handles_legacy_no_z_timestamp(self):
+        """A polling row with a legacy (no-Z) updated_at must still be
+        flagged stale once its age exceeds the timeout."""
+        jid = self.store.insert_job(
+            endpoint="http://a:8000", submit_tool="g", args="{}",
+        )
+        self._insert_with_raw_updated_at(jid, "polling",
+                                         "2020-01-01T00:00:00.000")
+
+        stale = self.store.get_stale_polling(timeout_seconds=60)
+        self.assertEqual(len(stale), 1)
+        self.assertEqual(stale[0]["id"], jid)
+
+    def test_get_stale_polling_handles_post_95ebebb_z_timestamp(self):
+        """A polling row with a Z-suffixed updated_at must also be
+        flagged stale once its age exceeds the timeout."""
+        jid = self.store.insert_job(
+            endpoint="http://a:8000", submit_tool="g", args="{}",
+        )
+        self._insert_with_raw_updated_at(jid, "polling",
+                                         "2020-01-01T00:00:00.000000Z")
+
+        stale = self.store.get_stale_polling(timeout_seconds=60)
+        self.assertEqual(len(stale), 1)
+        self.assertEqual(stale[0]["id"], jid)
+
+
 class TestRecoveringEndpoints(unittest.TestCase):
     """Querying recovering jobs for the dispatcher."""
 

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_dispatcher_rate_limit.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_dispatcher_rate_limit.py
@@ -1,8 +1,30 @@
 # -*- coding: utf-8 -*-
 """Tests for Dispatcher._run_job rate-limit handling.
 
-Verifies that 429 errors cause jobs to be requeued (pending/recovering)
-instead of marked as failed, and that pause_endpoint is called.
+Verifies that 429 errors cause jobs to be requeued and that
+pause_endpoint is called with the per-category cooldown duration.
+
+Spec history (important — do not "restore" the old behaviour without
+re-evaluating it against kamuicode MCP):
+
+* PR #40 (commit 64424c1) introduced the original 429 handler that read
+  the ``Retry-After`` header (capped at 60s), defaulted to 30s, and
+  routed jobs with ``remote_job_id`` to ``recovering``.
+* **PR #47 (commit 742527a) intentionally rewrote this** to:
+    - **Ignore the ``Retry-After`` header.** kamuicode MCP does NOT
+      return reliable Retry-After values (e.g. daily-limit 429s come
+      back as ordinary 429s with no distinguishing header), so trusting
+      the server's self-reported wait time is unsafe.
+    - **Use the per-category rolling-window cooldown** (default 3600s)
+      to suppress the entire category, since 429 responses do not count
+      toward the server's own rate window — overshooting the wait costs
+      the client nothing while undershooting causes more 429s.
+    - **Always re-queue to ``pending``**, regardless of ``remote_job_id``,
+      because the dispatcher's category-cooldown guard is what protects
+      the next dispatch.
+* Tests below were updated in PR #59 (lazy-v2.11.0) to reflect this
+  intent. The tests had been failing silently since PR #47 because the
+  old expectations were never adjusted.
 """
 import os
 import sys
@@ -74,8 +96,16 @@ class TestRunJob429Handling(unittest.TestCase):
         updated = self.store.get_job(job_id)
         self.assertEqual(updated["status"], "pending")
 
-    def test_run_job_429_with_remote_id_requeues_to_recovering(self):
-        """A 429 on a job with remote_job_id should requeue to recovering."""
+    def test_run_job_429_requeues_to_pending_regardless_of_remote_id(self):
+        """A 429 always re-queues to ``pending``, even when the job was
+        already polling with a ``remote_job_id`` (PR #47 behaviour).
+
+        Rationale: the per-category cooldown takes care of throttling, so
+        the dispatcher does not need to distinguish "submit again" from
+        "resume polling". Treating both uniformly keeps the recovery
+        path simple and avoids polling a remote job that the server may
+        have dropped while we were rate-limited.
+        """
         resp = _FakeResponse(429)
 
         def failing_executor(job):
@@ -98,17 +128,26 @@ class TestRunJob429Handling(unittest.TestCase):
         dispatcher._run_job(job)
 
         updated = self.store.get_job(job_id)
-        self.assertEqual(updated["status"], "recovering")
+        self.assertEqual(updated["status"], "pending")
 
-    def test_run_job_429_pauses_endpoint(self):
-        """A 429 should call pause_endpoint with Retry-After duration."""
+    def test_run_job_429_pauses_endpoint_with_per_category_cooldown(self):
+        """A 429 pauses the endpoint for the per-category cooldown duration.
+
+        ``Retry-After`` is intentionally ignored (see module docstring).
+        For an endpoint without a recognised category the default cooldown
+        falls back to ``HARDCODED_DEFAULT_EXHAUST_COOLDOWN`` (3600s).
+        """
         resp = _FakeResponse(429, headers={"Retry-After": "15"})
-        endpoint = "https://example.com/mcp"
+        # Use a kamuicode-style URL so extract_category() returns a real
+        # category (`t2i`). This anchors the test to the real per-category
+        # cooldown lookup path rather than the unknown-category fallback.
+        endpoint = "https://kamui-code.ai/t2i/fal/flux-lora"
 
         def failing_executor(job):
             raise _FakeHTTPError(response=resp)
 
         dispatcher = self._make_dispatcher(failing_executor)
+        expected_cooldown = dispatcher.category_limiter.get_exhaust_cooldown("t2i")
 
         job_id = self.store.insert_job(
             endpoint=endpoint,
@@ -123,14 +162,17 @@ class TestRunJob429Handling(unittest.TestCase):
         # pause_until should be set for this endpoint
         self.assertIn(endpoint, dispatcher._pause_until)
         remaining = dispatcher._pause_until[endpoint] - time.monotonic()
-        # Should be roughly 15 seconds (allow some tolerance)
-        self.assertGreater(remaining, 10.0)
-        self.assertLessEqual(remaining, 15.0)
+        # Retry-After=15 is ignored; pause is the per-category cooldown.
+        self.assertGreater(remaining, expected_cooldown - 5.0)
+        self.assertLessEqual(remaining, expected_cooldown)
 
-    def test_run_job_429_default_pause_without_retry_after(self):
-        """A 429 without Retry-After should pause for 30 seconds."""
+    def test_run_job_429_default_pause_uses_hardcoded_when_unknown_category(self):
+        """A 429 from an unknown-category endpoint pauses for the
+        hardcoded default cooldown (3600s)."""
+        from job_queue.category_limiter import HARDCODED_DEFAULT_EXHAUST_COOLDOWN
+
         resp = _FakeResponse(429)
-        endpoint = "https://example.com/mcp"
+        endpoint = "https://example.com/mcp"  # no t2i/i2i/t2v/i2v prefix
 
         def failing_executor(job):
             raise _FakeHTTPError(response=resp)
@@ -148,8 +190,8 @@ class TestRunJob429Handling(unittest.TestCase):
         dispatcher._run_job(job)
 
         remaining = dispatcher._pause_until[endpoint] - time.monotonic()
-        self.assertGreater(remaining, 25.0)
-        self.assertLessEqual(remaining, 30.0)
+        self.assertGreater(remaining, HARDCODED_DEFAULT_EXHAUST_COOLDOWN - 5.0)
+        self.assertLessEqual(remaining, HARDCODED_DEFAULT_EXHAUST_COOLDOWN)
 
     def test_run_job_non_429_marks_failed(self):
         """A non-429 error should mark the job as failed (existing behavior)."""

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_dispatcher_rate_limit.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_dispatcher_rate_limit.py
@@ -238,5 +238,97 @@ class TestRunJob429Handling(unittest.TestCase):
         self.assertIn("something broke", updated["error"])
 
 
+class TestUnknownCategoryEndpointDispatch(unittest.TestCase):
+    """An endpoint whose URL doesn't carry a recognised category prefix
+    (i.e. ``extract_category()`` returns None) must still be dispatchable
+    — the limiter is bypassed entirely for category-less endpoints.
+
+    This pins down the dispatcher contract that PR #59's CategoryLimiter
+    relies on: ``can_submit(None) == True`` plus ``acquire_inflight(None)
+    == False`` together mean "let the dispatcher schedule this job, but
+    don't create category-level inflight state for it". Without this
+    test, a future change that makes ``can_submit(None)`` return False
+    (or that mistakenly funnels None through the category accounting
+    path) could silently strand category-less jobs in pending forever.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.store = JobStore(self.tmp.name)
+        self.config = QueueConfig()
+        self.executed: list[str] = []
+
+    def tearDown(self):
+        self.store.close()
+        os.unlink(self.tmp.name)
+
+    def _make_dispatcher_recording(self):
+        def recording_executor(job):
+            self.executed.append(job["id"])
+
+        return Dispatcher(
+            store=self.store,
+            config=self.config,
+            job_executor=recording_executor,
+            loop_interval=0.01,
+        )
+
+    def test_category_less_endpoint_gets_dispatched(self):
+        """A pending job on an endpoint with no t2i/i2i/t2v/i2v prefix
+        must transition out of pending in a single dispatch round."""
+        dispatcher = self._make_dispatcher_recording()
+
+        # Sanity: this URL has no recognised category prefix
+        endpoint = "https://example.com/some/random/path"
+        self.assertIsNone(
+            dispatcher.category_limiter.extract_category(endpoint),
+            "Test premise: endpoint must have no recognised category",
+        )
+
+        job_id = self.store.insert_job(
+            endpoint=endpoint,
+            submit_tool="submit",
+            args="{}",
+        )
+
+        # One dispatch round should pick it up.
+        dispatched = dispatcher.dispatch_once()
+
+        self.assertEqual(dispatched, 1,
+                         "Category-less endpoint must be dispatchable")
+        # And the executor should eventually run (give the thread pool a moment)
+        for _ in range(50):
+            if self.executed:
+                break
+            time.sleep(0.02)
+        self.assertEqual(self.executed, [job_id])
+
+        dispatcher.stop()
+
+    def test_category_less_endpoint_creates_no_category_inflight_state(self):
+        """Dispatching a category-less endpoint must not leave any
+        per-category inflight state behind. Only acquire_inflight(None)
+        is called, which returns False without touching the dict."""
+        dispatcher = self._make_dispatcher_recording()
+        endpoint = "https://example.com/some/random/path"
+
+        job_id = self.store.insert_job(
+            endpoint=endpoint, submit_tool="submit", args="{}",
+        )
+        dispatcher.dispatch_once()
+
+        # Wait for the executor to finish
+        for _ in range(50):
+            if self.executed:
+                break
+            time.sleep(0.02)
+
+        # No category accounting created
+        self.assertEqual(dispatcher.category_limiter._inflight, {})
+
+        dispatcher.stop()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_executor.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_executor.py
@@ -227,8 +227,34 @@ class TestExecuteJobWithRetry(unittest.TestCase):
 
     @patch("mcp_worker_daemon.MCPAsyncClient")
     @patch("mcp_worker_daemon.parse_status_response")
-    def test_recovery_job_skips_submit(self, mock_parse, MockClient):
-        """Recovery job (has remote_job_id): should skip submit, start from poll."""
+    def test_recovery_job_skips_submit_and_uses_fresh_session(self, mock_parse, MockClient):
+        """Recovery job (has remote_job_id): submit is skipped, but a
+        FRESH session is used for polling — the DB-stored ``session_id``
+        is intentionally discarded.
+
+        Architecture rationale (see PR #47):
+
+        * ``session_id`` (``Mcp-Session-Id``) is the **kamuicode MCP**
+          middleware session. Its lifetime is short — bounded by the
+          middleware's session timeout. By the time we recover a job,
+          this session is almost always already expired on the server.
+        * ``remote_job_id`` is the **upstream provider's** (e.g. fal.ai)
+          job id. The provider keeps these around for a long time
+          regardless of which middleware session originally submitted.
+
+        Therefore recovery polls with a fresh middleware session and the
+        long-lived ``remote_job_id``. The original ``session_id`` value
+        from the DB is not propagated to the client, even though the
+        column is still written on the way in for diagnostics / future
+        compat.
+
+        Before PR #47 this test asserted the opposite (that the old
+        ``session_id`` was restored on the mocked client). That
+        expectation became stale once SessionManager was introduced and
+        the recovery path switched to ``_make_client(endpoint, headers)``
+        without ``session_id=...``. The assertion was updated in PR #59
+        (lazy-v2.11.0) to match the intentional behaviour.
+        """
         from mcp_worker_daemon import create_mcp_job_executor
 
         client_instance = MockClient.return_value
@@ -254,12 +280,20 @@ class TestExecuteJobWithRetry(unittest.TestCase):
         job = self.store.get_job(job_id)
         executor(job)
 
-        # submit should NOT have been called
+        # submit should NOT have been called — recovery skips submit.
         client_instance.submit.assert_not_called()
-        # session_id should be set from the job
-        self.assertEqual(client_instance.session_id, "old-sess")
-        # get_result should have been called
+
+        # The DB-stored session_id is NOT propagated to the client.
+        # (We don't assert "session_id is unset" because MCPAsyncClient
+        # is fully mocked here — we instead assert that get_result was
+        # called with the recovery remote_job_id, which is the only
+        # contract that matters for the recovery path.)
         client_instance.get_result.assert_called_once()
+        get_result_args = client_instance.get_result.call_args
+        # First positional arg is the result_tool name; second is the
+        # remote job id. The recovery path must use the DB-stored
+        # remote_job_id verbatim.
+        self.assertEqual(get_result_args.args[1], "old-req")
 
         final = self.store.get_job(job_id)
         self.assertEqual(final["status"], "completed")

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_worker_config.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_worker_config.py
@@ -1,0 +1,357 @@
+# -*- coding: utf-8 -*-
+"""Tests for worker.py ``GET /api/config`` and ``PATCH /api/config`` (#59).
+
+Covers:
+
+* GET response includes the new per-category ``limits.{cat}.{key}`` shape
+  AND the legacy mirror keys (``category.max_inflight`` etc.) for
+  lazy-v2.10.x dashboard compatibility.
+* PATCH accepts the new per-category form.
+* PATCH accepts the legacy flat form (fans out to ALL configured
+  categories with an ``_legacy_warning`` in ``applied``).
+* PATCH validates types: ``category.limits`` rejects non-dict
+  (including explicit ``null``), ``category.limits.{cat}`` rejects
+  non-dict, individual fields enforce min values.
+* Three-way upgrade compatibility: legacy queue_config + new dispatcher
+  + old dashboard read path keeps working.
+"""
+import os
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import requests
+
+from job_queue import worker
+
+
+def get_free_port():
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _CategoryConfigBase(unittest.TestCase):
+    """Base class that boots a worker with a known per-category config."""
+
+    config_override: dict | None = None
+
+    def setUp(self):
+        self.port = get_free_port()
+        self.base_url = f"http://127.0.0.1:{self.port}"
+
+        config_dict = self.config_override or {
+            "default_rate_limit": {
+                "max_concurrent_jobs": 5,
+                "min_interval_seconds": 0.0,
+            },
+            "category_rate_limits": {
+                "categories": ["t2i", "i2i", "t2v", "i2v"],
+                "limits": {
+                    "t2i": {"max_inflight": 3, "min_interval": 0.0,
+                             "exhaust_cooldown": 60},
+                    "i2i": {"max_inflight": 2, "min_interval": 0.0,
+                             "exhaust_cooldown": 120},
+                    "t2v": {"max_inflight": 1, "min_interval": 0.0,
+                             "exhaust_cooldown": 1800},
+                    "i2v": {"max_inflight": 1, "min_interval": 0.0,
+                             "exhaust_cooldown": 3600},
+                },
+            },
+        }
+
+        self.worker_app = worker.WorkerApp(
+            host="127.0.0.1",
+            port=self.port,
+            db_path=":memory:",
+            config_dict=config_dict,
+            job_executor=lambda job: None,
+            idle_timeout=0,
+        )
+        self.worker_app.start()
+
+        for _ in range(50):
+            try:
+                requests.get(f"{self.base_url}/api/health", timeout=0.5)
+                break
+            except requests.ConnectionError:
+                time.sleep(0.05)
+
+    def tearDown(self):
+        self.worker_app.stop()
+
+
+class TestGetConfigShape(_CategoryConfigBase):
+    """GET /api/config returns the new per-category shape with mirror keys."""
+
+    def test_returns_per_category_limits(self):
+        resp = requests.get(f"{self.base_url}/api/config")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+
+        self.assertIn("category", data)
+        self.assertIn("limits", data["category"])
+        limits = data["category"]["limits"]
+        self.assertEqual(set(limits.keys()), {"t2i", "i2i", "t2v", "i2v"})
+        self.assertEqual(limits["t2i"]["max_inflight"], 3)
+        self.assertEqual(limits["t2v"]["exhaust_cooldown"], 1800)
+
+    def test_includes_legacy_mirror_keys_for_old_dashboard(self):
+        """The pre-v2.11 dashboard reads ``cfg.category.max_inflight`` etc.
+        directly. We mirror the first category's values into top-level
+        keys so its UI does not go blank."""
+        resp = requests.get(f"{self.base_url}/api/config")
+        data = resp.json()
+
+        self.assertIn("max_inflight", data["category"])
+        self.assertIn("min_interval", data["category"])
+        self.assertIn("exhaust_cooldown", data["category"])
+
+        # First category alphabetically is "i2i" (max_inflight=2)
+        self.assertEqual(data["category"]["max_inflight"], 2)
+        self.assertEqual(data["category"]["exhaust_cooldown"], 120)
+
+
+class TestPatchNewForm(_CategoryConfigBase):
+    """PATCH /api/config with the new per-category shape."""
+
+    def test_patch_single_category_max_inflight(self):
+        body = {"category": {"limits": {"t2v": {"max_inflight": 5}}}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("category.limits.t2v.max_inflight", data["applied"])
+        self.assertEqual(data["applied"]["category.limits.t2v.max_inflight"], 5)
+        self.assertEqual(data["rejected"], {})
+
+        # Verify the change is reflected in subsequent GET
+        cfg = requests.get(f"{self.base_url}/api/config").json()
+        self.assertEqual(cfg["category"]["limits"]["t2v"]["max_inflight"], 5)
+        # Other categories untouched
+        self.assertEqual(cfg["category"]["limits"]["t2i"]["max_inflight"], 3)
+
+    def test_patch_multiple_categories_in_one_request(self):
+        body = {"category": {"limits": {
+            "t2i": {"max_inflight": 7, "exhaust_cooldown": 300},
+            "t2v": {"exhaust_cooldown": 7200},
+        }}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        data = resp.json()
+        self.assertEqual(data["rejected"], {})
+
+        cfg = requests.get(f"{self.base_url}/api/config").json()
+        self.assertEqual(cfg["category"]["limits"]["t2i"]["max_inflight"], 7)
+        self.assertEqual(cfg["category"]["limits"]["t2i"]["exhaust_cooldown"], 300)
+        self.assertEqual(cfg["category"]["limits"]["t2v"]["exhaust_cooldown"], 7200)
+
+
+class TestPatchLegacyForm(_CategoryConfigBase):
+    """PATCH /api/config with the legacy flat shape — applied to all
+    configured categories with a warning in ``applied``."""
+
+    def test_legacy_max_inflight_applies_to_all_categories(self):
+        body = {"category": {"max_inflight": 9}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+
+        # _legacy_warning should be present
+        self.assertIn("_legacy_warning", data["applied"])
+        self.assertIn("legacy", data["applied"]["_legacy_warning"].lower())
+
+        # The fan-out result should list affected categories
+        applied = data["applied"]["category.max_inflight"]
+        self.assertEqual(applied["value"], 9)
+        self.assertEqual(set(applied["affected"]),
+                         {"t2i", "i2i", "t2v", "i2v"})
+
+        # All categories now have max_inflight=9
+        cfg = requests.get(f"{self.base_url}/api/config").json()
+        for cat in ["t2i", "i2i", "t2v", "i2v"]:
+            self.assertEqual(
+                cfg["category"]["limits"][cat]["max_inflight"], 9,
+                msg=f"category {cat} should have max_inflight=9",
+            )
+
+    def test_legacy_does_not_overwrite_explicit_per_category(self):
+        """If both shapes are in the same PATCH, the per-category
+        ``limits`` block wins for the categories it covers."""
+        body = {"category": {
+            "limits": {"t2v": {"max_inflight": 1}},  # explicit
+            "max_inflight": 5,  # legacy fan-out for everyone else
+        }}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertEqual(resp.status_code, 200)
+
+        cfg = requests.get(f"{self.base_url}/api/config").json()
+        # t2v keeps its explicit value
+        self.assertEqual(cfg["category"]["limits"]["t2v"]["max_inflight"], 1)
+        # Others got the legacy fan-out
+        self.assertEqual(cfg["category"]["limits"]["t2i"]["max_inflight"], 5)
+        self.assertEqual(cfg["category"]["limits"]["i2i"]["max_inflight"], 5)
+        self.assertEqual(cfg["category"]["limits"]["i2v"]["max_inflight"], 5)
+
+
+class TestPatchRejection(_CategoryConfigBase):
+    """PATCH /api/config validates types and value ranges."""
+
+    def test_limits_must_be_dict_not_list(self):
+        body = {"category": {"limits": [1, 2, 3]}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        data = resp.json()
+        self.assertIn("category.limits", data["rejected"])
+        self.assertIn("must be object", data["rejected"]["category.limits"])
+
+    def test_limits_must_be_dict_not_int(self):
+        body = {"category": {"limits": 42}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertIn("category.limits", resp.json()["rejected"])
+
+    def test_limits_must_be_dict_not_string(self):
+        body = {"category": {"limits": "all"}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertIn("category.limits", resp.json()["rejected"])
+
+    def test_limits_explicit_null_rejected(self):
+        """v3 fix M1: explicit ``null`` is NOT the same as "key absent".
+        It is rejected to avoid silently masking config typos."""
+        body = {"category": {"limits": None}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertIn("category.limits", resp.json()["rejected"])
+
+    def test_per_category_value_must_be_dict(self):
+        body = {"category": {"limits": {"t2v": [1, 2]}}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertIn("category.limits.t2v", resp.json()["rejected"])
+
+    def test_unknown_category_rejected(self):
+        body = {"category": {"limits": {"foobar": {"max_inflight": 1}}}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        rejected = resp.json()["rejected"]
+        self.assertIn("category.limits.foobar", rejected)
+        self.assertIn("unknown category", rejected["category.limits.foobar"])
+
+    def test_max_inflight_must_be_int_ge_1(self):
+        body = {"category": {"limits": {"t2v": {"max_inflight": 0}}}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertIn("category.limits.t2v.max_inflight",
+                      resp.json()["rejected"])
+
+    def test_max_inflight_must_be_int_not_string(self):
+        body = {"category": {"limits": {"t2v": {"max_inflight": "five"}}}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertIn("category.limits.t2v.max_inflight",
+                      resp.json()["rejected"])
+
+    def test_exhaust_cooldown_must_be_non_negative(self):
+        body = {"category": {"limits": {"t2v": {"exhaust_cooldown": -1}}}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertIn("category.limits.t2v.exhaust_cooldown",
+                      resp.json()["rejected"])
+
+    def test_partial_failure_applies_valid_and_rejects_invalid(self):
+        """A PATCH with a mix of valid and invalid fields applies the
+        valid ones and reports the invalid ones in ``rejected``."""
+        body = {"category": {"limits": {
+            "t2v": {
+                "max_inflight": 4,        # valid
+                "exhaust_cooldown": -1,   # invalid
+            },
+        }}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        data = resp.json()
+        self.assertEqual(data["rejected"]["category.limits.t2v.exhaust_cooldown"],
+                         "must be float >= 0")
+        self.assertEqual(data["applied"]["category.limits.t2v.max_inflight"], 4)
+
+        # The valid update is reflected
+        cfg = requests.get(f"{self.base_url}/api/config").json()
+        self.assertEqual(cfg["category"]["limits"]["t2v"]["max_inflight"], 4)
+        # The invalid one didn't change anything
+        self.assertEqual(cfg["category"]["limits"]["t2v"]["exhaust_cooldown"],
+                         1800)
+
+
+class TestUpgradeCompat(unittest.TestCase):
+    """Three-way compatibility for users who upgrade mcp-async-skill but
+    keep their lazy-v2.10.x ``queue_config.json`` and ``queue-dashboard``.
+
+    The legacy queue_config below is exactly the shape produced by
+    ``generate_queue_config()`` in lazy-v2.10.x.
+    """
+
+    def setUp(self):
+        self.port = get_free_port()
+        self.base_url = f"http://127.0.0.1:{self.port}"
+
+        legacy_queue_config = {
+            "default_rate_limit": {
+                "max_concurrent_jobs": 5,
+                "min_interval_seconds": 0.0,
+            },
+            "category_rate_limits": {
+                "categories": ["t2i", "i2i", "t2v", "i2v"],
+                "aliases": {"r2i": "i2i", "r2v": "i2v"},
+                "min_interval": 1.0,
+                "max_category_inflight": 1,
+                "exhaust_cooldown": 3600,
+            },
+        }
+
+        self.worker_app = worker.WorkerApp(
+            host="127.0.0.1",
+            port=self.port,
+            db_path=":memory:",
+            config_dict=legacy_queue_config,
+            job_executor=lambda job: None,
+            idle_timeout=0,
+        )
+        self.worker_app.start()
+
+        for _ in range(50):
+            try:
+                requests.get(f"{self.base_url}/api/health", timeout=0.5)
+                break
+            except requests.ConnectionError:
+                time.sleep(0.05)
+
+    def tearDown(self):
+        self.worker_app.stop()
+
+    def test_legacy_queue_config_works_with_new_dispatcher(self):
+        """Worker boots from a lazy-v2.10.x queue_config.json and
+        exposes both new + legacy shape via /api/config."""
+        cfg = requests.get(f"{self.base_url}/api/config").json()
+
+        # New shape: every category has the legacy fan-out value
+        for cat in ["t2i", "i2i", "t2v", "i2v"]:
+            self.assertEqual(
+                cfg["category"]["limits"][cat]["max_inflight"], 1)
+            self.assertEqual(
+                cfg["category"]["limits"][cat]["exhaust_cooldown"], 3600)
+
+        # Mirror keys: present and consistent
+        self.assertEqual(cfg["category"]["max_inflight"], 1)
+        self.assertEqual(cfg["category"]["exhaust_cooldown"], 3600)
+
+    def test_legacy_dashboard_patch_through_legacy_form_still_works(self):
+        """Old dashboard sends ``{"category": {"max_inflight": 2}}``.
+        New worker fans out to all categories and reports
+        ``_legacy_warning`` so the change is visible in tooling."""
+        body = {"category": {"max_inflight": 2}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("_legacy_warning", data["applied"])
+
+        cfg = requests.get(f"{self.base_url}/api/config").json()
+        for cat in ["t2i", "i2i", "t2v", "i2v"]:
+            self.assertEqual(
+                cfg["category"]["limits"][cat]["max_inflight"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Queue runtime data (SQLite DB, results)
 .claude/queue/
 
+# Claude Code worktrees (local working branches and notes)
+.claude/worktrees/
+
 # Old directory
 old/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [Unreleased] — targeting lazy-v2.11.0
+
+### Added
+- **Per-category individual rate limits** (#59): t2i / i2i / t2v / i2v ごとに `max_inflight` / `min_interval` / `exhaust_cooldown` を独立設定可能
+  - 新スキーマ `category_rate_limits.limits.{cat}.{key}` (旧スキーマ `max_category_inflight` は後方互換ロード + 1 回 deprecation log、`lazy-v2.13.0 以降で削除予定`)
+  - `PATCH /api/config` 新形式: `{"category": {"limits": {"t2v": {"max_inflight": 1}}}}`
+  - 旧 `lazy-v2.10.x dashboard` 互換: 旧形式 PATCH (`{"category": {"max_inflight": N}}`) を全カテゴリ一括適用として受理 (`_legacy_warning` を applied[] に含む)
+  - `GET /api/config` レスポンスに新キーと旧互換ミラーキー (`category.max_inflight` 等、最初のカテゴリの値) を併記
+  - `category_limiter.py` の public API 拡張: `is_known_category()`, `get_categories()`, `get_max_inflight(cat)`, `get_min_interval(cat)`, `get_exhaust_cooldown(cat)`
+  - 詳細: [docs/category-limits.md](docs/category-limits.md)
+- 新規テスト: `test_category_limiter.py` (37 tests), `test_worker_config.py` (18 tests), 並行性 / 後方互換 / 入力検証 / unknown endpoint dispatch / legacy timestamp parse をカバー
+
+### Changed (BREAKING)
+- **`set_max_inflight(cat, value)` の `cat` 引数必須化**: lazy-v2.10.x の単一引数 `set_max_inflight(value)` (全カテゴリ一括変更) は削除。`set_min_interval` / `set_exhaust_cooldown` も同様。worker の `PATCH /api/config` ハンドラが「全カテゴリ一括」の API レイヤを emulate する。
+- **`acquire_inflight("unknown") == can_submit("unknown") == False` に統一**: lazy-v2.10.x では unknown でハードコード default の inflight state を作っていたが、`can_submit` と整合しない不整合だった。現在は unknown は category accounting 対象外。dispatcher は `extract_category() is None` のとき category check をスキップする経路を従来から持っている。
+- `dispatcher.py` の `category_limiter._exhaust_cooldown` 直接参照を `get_exhaust_cooldown(category)` 公開 API 経由に変更 (per-category 化への移行で private 直触りが壊れるため)。
+
+### Fixed
+- **`db.py` purge_old_jobs / get_stale_polling のタイムスタンプ精度バグ** (PR #45 由来の silent failure):
+  - `95ebebb` で `update_status` が `_utc_now_iso()` (μs 精度) に切り替わったが、`purge_old_jobs` と `get_stale_polling` は SQL の `julianday('now')` (秒精度) を使い続けていた。Python 側のタイムスタンプが SQL の `now` より数百 μs 未来になり、経過時間が負になって `retention_seconds=0` でも 0 件削除になっていた。
+  - 修正: `_utc_now_iso()` をバインドパラメータとして渡し、両辺で同じ Python wall-clock を使用。
+- **`test_dispatcher_rate_limit.py` の 429 期待値** (PR #47 で意図的に変更されたが test 未更新):
+  - `Retry-After` ヘッダー無視 (kamuicode MCP は信頼できる Retry-After を返さない)
+  - per-category cooldown 適用 (デフォルト 3600s)
+  - 一律 `pending` に再キュー (remote_job_id があっても recovering にしない)
+  - テストを現仕様に合わせて書き直し、PR #47 の判断理由を docstring に明記
+- **`test_executor.py` の recovery session 期待値** (PR #47 SessionManager 導入で変更されたが test 未更新):
+  - kamuicode MCP の中継 session は短命、fal.ai の remote_job_id は長命というアーキテクチャに基づき、recovery 時は古い session_id を捨てて fresh middleware session で remote_job_id を polling する
+  - テストを「fresh session + remote_job_id 経由 polling」期待に書き直し
+
+### Compatibility
+- **lazy-v2.10.x の queue_config.json (旧 flat schema) は引き続き動作**します (起動時に `[CategoryLimiter] (instance ...) DEPRECATED: ...` 警告ログが 1 回出力)
+- **lazy-v2.10.x dashboard は引き続き動作**します (`GET /api/config` の旧互換ミラーキーで UI 値が空にならない)。ただし旧 dashboard から値編集すると **新 worker は全カテゴリに一括適用** します。per-category 編集には `lazy-v2.12.0` 以降の dashboard が必要。
+
 ## [lazy-v2.10.0](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/releases/tag/lazy-v2.10.0) (2026-04-23)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Claude Code用のMCPスキルジェネレーター。非同期ジョブパター
 | **複数ファイル対応** | レスポンス内の全URLを再帰探索し一括ダウンロード。連番サフィックス自動付与 | 自動 | [📖](docs/output-path-strategy.md) |
 | **キューシステム** | ローカルワーカーによるエンドポイント別レートリミットと並行数制御。自動起動・自動終了 | `--queue-config` | [📖](docs/queue_system_design.md) |
 | **キュー堅牢化** | ゾンビジョブ回復・指数バックオフリトライ・429 Retry-After対応・ワーカー側ダウンロード | 自動 | [📖](docs/queue_system_hardening.md) |
-| **カテゴリ別制御** | t2i/i2i/t2v/i2vカテゴリ単位でのinflight制御・429自動リトライ・非429エラー時のカテゴリ即pause | 自動 | |
+| **カテゴリ別制御** | t2i/i2i/t2v/i2vカテゴリ単位でのinflight制御・429自動リトライ・非429エラー時のカテゴリ即pause | 自動 | [📖](docs/category-limits.md) |
+| **per-category 個別レートリミット** | 各カテゴリに独立した max_inflight / min_interval / exhaust_cooldown を設定可能 (`limits.{cat}.{key}`)。サービス側のカテゴリ別レートリミットに合わせて調整 | `queue_config.json` | [📖](docs/category-limits.md) |
 | **セッション管理** | MCPセッションをendpoint単位でキャッシュ。認証サーバーへの負荷を削減 | 自動 | |
 | **カテゴリpause/resume** | カテゴリ単位での手動一時停止・再開。他端末との枠共有時に便利 | `--pause-category` | |
 | **Queue Dashboard** | ブラウザから見えるキュー可視化Web UI。サマリー/カテゴリ/ジョブ一覧/失敗詳細/pause-resume。追加依存なし（Python stdlib + Vanilla JS） | 独立スキル | |
@@ -537,17 +538,19 @@ python mcp_async_call.py --resume-category t2i
   "category_rate_limits": {
     "categories": ["t2i", "i2i", "t2v", "i2v"],
     "aliases": {"r2i": "i2i", "r2v": "i2v"},
-    "min_interval": 1.0,
-    "max_category_inflight": 1,
-    "exhaust_cooldown": 3600,
-    "auto_pause_after_consecutive_429": 25
+    "limits": {
+      "t2i": {"max_inflight": 3, "min_interval": 1.0, "exhaust_cooldown": 600},
+      "i2i": {"max_inflight": 2, "min_interval": 1.0, "exhaust_cooldown": 3600},
+      "t2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 1800},
+      "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
+    }
   },
   "job_retention_seconds": 86400,
   "results_dir": ".claude/queue/results"
 }
 ```
 
-> 📖 詳細: [キューシステム設計](docs/queue_system_design.md) / [堅牢化設計](docs/queue_system_hardening.md)
+> 📖 詳細: [キューシステム設計](docs/queue_system_design.md) / [堅牢化設計](docs/queue_system_hardening.md) / [カテゴリ別レートリミット (per-category limits)](docs/category-limits.md)
 
 ## エラーハンドリング
 

--- a/docs/category-limits.md
+++ b/docs/category-limits.md
@@ -1,0 +1,201 @@
+# Per-Category Rate Limits
+
+`lazy-v2.11.0` 以降、カテゴリ (`t2i` / `i2i` / `t2v` / `i2v`) ごとに inflight・min_interval・429 cooldown を **独立した値で設定可能**になりました。アップストリーム MCP サービス側もカテゴリごとにローリング窓レートリミットを分けて運用しているため、クライアント側でも対応する個別値を設定できます。
+
+## 設定スキーマ (`queue_config.json`)
+
+### 新形式 (`lazy-v2.11.0+` 推奨)
+
+```json
+{
+  "category_rate_limits": {
+    "categories": ["t2i", "i2i", "t2v", "i2v"],
+    "aliases": {"r2i": "i2i", "r2v": "i2v"},
+    "limits": {
+      "t2i": {"max_inflight": 3, "min_interval": 1.0, "exhaust_cooldown": 600},
+      "i2i": {"max_inflight": 2, "min_interval": 1.0, "exhaust_cooldown": 3600},
+      "t2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 1800},
+      "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
+    }
+  }
+}
+```
+
+各キー：
+
+| キー | 意味 | 既定値 (key 未指定時) |
+|---|---|---|
+| `max_inflight` | 同時に submit 中にできるジョブ数 | `1` |
+| `min_interval` | 同カテゴリ内の submit 間隔 (秒) | `1.0` |
+| `exhaust_cooldown` | 429 を 1 回受けた後にカテゴリ全体を抑制する秒数 | `3600` |
+
+### 旧形式 (lazy-v2.10.x、後方互換ロード)
+
+```json
+{
+  "category_rate_limits": {
+    "categories": ["t2i", "i2i", "t2v", "i2v"],
+    "aliases": {"r2i": "i2i", "r2v": "i2v"},
+    "max_category_inflight": 1,
+    "min_interval": 1.0,
+    "exhaust_cooldown": 3600
+  }
+}
+```
+
+旧形式の値は **すべての設定済みカテゴリに同じ値で展開** されます。worker 起動時に `[CategoryLimiter] (instance ...) DEPRECATED: ...` という警告ログが 1 回出力されます。
+旧形式は `lazy-v2.13.0 以降で削除予定` です。新規インストールでは新形式を使用してください。
+
+### Fallback 挙動
+
+設定漏れに対する保険として、`limits.{cat}` または個別キーが欠けている場合はモジュールレベルのハードコード初期値 (`max_inflight=1`, `min_interval=1.0`, `exhaust_cooldown=3600`) が使われます。**正規の運用では `limits` を 4 カテゴリ × 3 キー全て明示してください。**
+
+## Runtime API (`PATCH /api/config`)
+
+実行中の worker に対して、`PATCH /api/config` で per-category 値を変更できます。
+
+### 新形式 (推奨)
+
+特定カテゴリだけ変えたいとき：
+
+#### bash
+
+```bash
+curl -X PATCH http://127.0.0.1:54321/api/config \
+  -H 'Content-Type: application/json' \
+  -d '{"category": {"limits": {"t2v": {"max_inflight": 1, "exhaust_cooldown": 1800}}}}'
+```
+
+#### PowerShell
+
+```powershell
+Invoke-RestMethod -Method Patch `
+  -Uri "http://127.0.0.1:54321/api/config" `
+  -Body (@{
+      category = @{
+          limits = @{
+              t2v = @{ max_inflight = 1; exhaust_cooldown = 1800 }
+          }
+      }
+  } | ConvertTo-Json -Depth 5) `
+  -ContentType "application/json"
+```
+
+レスポンス例：
+
+```json
+{
+  "applied": {
+    "category.limits.t2v.max_inflight": 1,
+    "category.limits.t2v.exhaust_cooldown": 1800
+  },
+  "rejected": {},
+  "requires_restart": []
+}
+```
+
+### 旧形式 (lazy-v2.10.x dashboard 互換)
+
+`lazy-v2.10.x dashboard` は新形式の per-category 入力 UI を持たず、旧形式 `{"category": {"max_inflight": N}}` を送ってきます。新 worker はこれを **全カテゴリへの一括適用** として受理します。
+
+#### bash
+
+```bash
+curl -X PATCH http://127.0.0.1:54321/api/config \
+  -H 'Content-Type: application/json' \
+  -d '{"category": {"max_inflight": 5}}'
+```
+
+レスポンス例：
+
+```json
+{
+  "applied": {
+    "_legacy_warning": "Received legacy flat category.{key} form; applied to all categories not covered by category.limits in this request. Migrate to category.limits.{cat}.{key} per-category form.",
+    "category.max_inflight": {"value": 5, "affected": ["i2i", "i2v", "t2i", "t2v"]}
+  },
+  "rejected": {}
+}
+```
+
+> **Warning**: 旧 `lazy-v2.10.x dashboard` から値編集 PATCH を投げると、新 worker は **全カテゴリに一括適用** します。最初のカテゴリの値だけを変えたつもりが全カテゴリに展開されるので注意してください。**per-category の独立編集を行うには `lazy-v2.12.0` 以降の dashboard が必要** です。
+
+### 入力検証
+
+`category.limits` は dict 必須。`null` / `int` / `list` / `string` などを渡すと reject されます。これは「キーを書き忘れた」と「明示的に空にしたい」を区別するための仕様で、設定ミスを silent に通さない安全弁です。
+
+```bash
+# 拒否される例
+curl -X PATCH http://127.0.0.1:54321/api/config \
+  -H 'Content-Type: application/json' \
+  -d '{"category": {"limits": null}}'
+# → rejected: {"category.limits": "must be object (got NoneType)"}
+```
+
+## 状態の確認 (`GET /api/config`, `GET /api/categories`)
+
+#### bash
+
+```bash
+# 現在の per-category 設定値を取得
+curl http://127.0.0.1:54321/api/config
+
+# カテゴリ別のリアルタイム状態 (inflight, cooldown_remaining_s, paused, etc.)
+curl http://127.0.0.1:54321/api/categories
+```
+
+#### PowerShell
+
+```powershell
+Invoke-RestMethod -Uri "http://127.0.0.1:54321/api/config" |
+  Select-Object -ExpandProperty category | ConvertTo-Json -Depth 5
+
+Invoke-RestMethod -Uri "http://127.0.0.1:54321/api/categories"
+```
+
+`GET /api/config` のレスポンス例：
+
+```json
+{
+  "category": {
+    "limits": {
+      "t2i": {"max_inflight": 3, "min_interval": 1.0, "exhaust_cooldown": 600},
+      "i2i": {"max_inflight": 2, "min_interval": 1.0, "exhaust_cooldown": 3600},
+      "t2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 1800},
+      "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
+    },
+    "max_inflight": 2,
+    "min_interval": 1.0,
+    "exhaust_cooldown": 3600
+  },
+  "endpoint": {...},
+  "worker": {...}
+}
+```
+
+`category.max_inflight` / `category.min_interval` / `category.exhaust_cooldown` は **lazy-v2.10.x dashboard 互換のためのミラーキー**で、`limits` を辞書順に並べたときの最初のカテゴリ (i2i) の値が入ります。`lazy-v2.13.0 以降で削除予定` です。
+
+## 後方互換マトリクス
+
+PR1 (lazy-v2.11.0) は次の組み合わせをすべてサポートします：
+
+| 利用者の状態 | queue_config | dispatcher | dashboard | 動作 |
+|---|---|---|---|---|
+| **新規インストール** | 新形式 (limits) | 新 (v2.11.0+) | 新 (v2.12.0+, 後続 PR) | フル機能 |
+| **mcp-async-skill のみ更新** | 旧形式 (legacy) | 新 (v2.11.0+) | 旧 (v2.10.x) | ✅ 全カテゴリ同値、旧 UI で編集可 |
+| **すべて新版** | 旧形式 (未編集) | 新 (v2.11.0+) | 新 (v2.12.0+) | ✅ 旧形式は legacy 展開で動作、警告 1 回 |
+
+### 既存ユーザーへの推奨アップグレード手順
+
+1. mcp-async-skill を `lazy-v2.11.0` 以降に上書きインストール (worker shutdown 推奨は #62 で扱う)
+2. `queue_config.json` の `category_rate_limits` セクションを新形式に書き換え (旧形式のままでも動くが警告ログが出る)
+3. 必要に応じて `limits.{cat}` の値をサービス側のレートリミットに合わせて調整
+
+## 設計判断ログ
+
+PR1 で議論し決定した仕様：
+
+- **`defaults` 階層を持たない (limits フラット構造)**: 「全カテゴリのデフォルトを一斉変更」という運用は実態として発生しない。サービス側のレートリミット変更は単一カテゴリだけに来るので、各カテゴリ独立の `limits.{cat}` 構造が直感的。
+- **未知カテゴリ (`get_max_inflight("unknown")` 等) はハードコード初期値を返す**: 例外を投げると dispatcher の境界条件で予期せず壊れる。debug log で気づける程度のソフトな扱い。
+- **`set_max_inflight(cat, value)` の cat 必須化 (BREAKING)**: lazy-v2.10.x の単一引数 setter は `set_max_inflight(value)` で全カテゴリ一括変更だったが、per-category 化に伴い必ずカテゴリ指定が必要。worker の `PATCH /api/config` ハンドラが「全カテゴリ一括」の API レイヤを emulate する。
+- **deprecation log は CategoryLimiter instance ごとに 1 回**: process global one-shot だと複数 worker / テスト環境で 1 回しか見えなくなる。instance ごとのほうが診断に役立つ。


### PR DESCRIPTION
## Summary

Closes #59 (Phase 1 PR1, targeting `lazy-v2.11.0`).

Allows `t2i` / `i2i` / `t2v` / `i2v` to have **independent** `max_inflight`, `min_interval`, and `exhaust_cooldown` values via the new `category_rate_limits.limits.{cat}.{key}` schema. The upstream MCP service applies per-category rolling-window rate limits, so the client must mirror that.

This PR is split into three concerns: **baseline test repair → feature implementation → tests + docs**. See commits below.

## Why this PR is bigger than just #59

The branch also contains `3cb89b8 fix(queue): repair 6 silent test failures inherited from PR #45/#47`. Three pre-existing test failures had been silently red on `main` since their respective merges. As discussed during planning, **\"修理を放置しては改修完了を判定できない\"** — landing per-category limits on top of a partially-broken test suite would have made regressions invisible. Each failure was traced to its introducing commit before fixing, so we know what changed and why.

| Failed test | Real root cause | Fix location |
|---|---|---|
| `test_db.py::TestPurgeOldJobs::*` (3) | `95ebebb` switched `update_status` to μs-precision Python timestamps but `purge_old_jobs` / `get_stale_polling` kept using `julianday('now')` (second precision) → elapsed time went negative → 0 rows deleted | `db.py` (real bug) |
| `test_dispatcher_rate_limit::TestRunJob429Handling::*` (3) | `742527a` (PR #47) intentionally rewrote 429 handling to per-category cooldown / always-pending / Retry-After-ignored — tests were never updated | tests rewritten with PR #47 rationale documented |
| `test_executor::test_recovery_job_skips_submit` (1) | `742527a` introduced SessionManager and switched recovery to fresh-session + remote_job_id polling — test was never updated | test rewritten to assert the architectural intent (kamuicode middleware session is short, fal job_id is long) |

## What changes for users

### New (`category_rate_limits.limits.{cat}.{key}`)

```json
{
  "category_rate_limits": {
    "categories": ["t2i", "i2i", "t2v", "i2v"],
    "aliases": {"r2i": "i2i", "r2v": "i2v"},
    "limits": {
      "t2i": {"max_inflight": 3, "min_interval": 1.0, "exhaust_cooldown": 600},
      "i2i": {"max_inflight": 2, "min_interval": 1.0, "exhaust_cooldown": 3600},
      "t2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 1800},
      "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
    }
  }
}
```

`PATCH /api/config` accepts the same shape:

\`\`\`bash
curl -X PATCH http://127.0.0.1:54321/api/config \
  -H 'Content-Type: application/json' \
  -d '{\"category\": {\"limits\": {\"t2v\": {\"exhaust_cooldown\": 7200}}}}'
\`\`\`

Full reference: [docs/category-limits.md](docs/category-limits.md).

### Compatibility

| Combination | Result |
|---|---|
| `lazy-v2.10.x queue_config.json` + new worker | ✅ Loaded as legacy flat schema, fanned out to all configured categories. One deprecation warning per `CategoryLimiter` instance. |
| `lazy-v2.10.x dashboard` (read) + new worker | ✅ `GET /api/config` mirrors first-by-name category's values to top-level `category.max_inflight` etc. so the legacy UI never goes blank. |
| `lazy-v2.10.x dashboard` (write) + new worker | ⚠️ Legacy PATCH (`{\"category\": {\"max_inflight\": N}}`) is accepted but **applied to ALL configured categories**, with `_legacy_warning` in the response. Per-category editing requires `lazy-v2.12.0+` dashboard. |

Legacy schema and mirror keys removal is **targeted at `lazy-v2.13.0` or later** (no fixed date).

### BREAKING (Python API)

- `set_max_inflight(value)` → `set_max_inflight(cat, value)` (and the same for `set_min_interval` / `set_exhaust_cooldown`). The worker's `PATCH /api/config` handler emulates the legacy fan-out at the API layer, so HTTP callers are unaffected.
- `acquire_inflight(\"unknown\") == can_submit(\"unknown\") == False` (was inconsistent: `can_submit` returned True, `acquire_inflight` created hardcoded-default state). Dispatcher already skipped category accounting when `extract_category() is None`, so endpoint-only jobs (URL with no `t2i/i2i/t2v/i2v` prefix) keep dispatching normally — pinned by `TestUnknownCategoryEndpointDispatch`.

## Verification

### Tests

```
$ pytest scripts/tests/ -q
299 passed in ~58s
```

Counts:

- baseline (origin/main): **238 collected, 6 failing** (silent regressions from PR #45/#47)
- this PR: **299 collected, 0 failing** (+55 new in `test_category_limiter.py` / `test_worker_config.py`, +6 in `TestUnknownCategoryEndpointDispatch` / `TestLegacyTimestampCompat`, all 6 baseline failures repaired)

### `rg` audit (no leftover private/legacy attribute access in `mcp-async-skill`)

```
$ rg "limiter\._exhaust_cooldown|limiter\._max_inflight|limiter\._min_interval|limiter\._categories|category_limiter\._exhaust_cooldown|category_limiter\._max_inflight|category_limiter\._min_interval|category_limiter\._categories" .claude/skills/mcp-async-skill/
(no matches)
```

`set_max_inflight` / `set_min_interval` / `set_exhaust_cooldown` callers in `mcp-async-skill` all go through `worker.py`'s `_CAT_KEY_SPEC` dispatch, which calls `setter(cat_name, v)` with the explicit category. Generated skill copies under `.claude/skills/{t2i,i2i,t2v,i2v,r2i,r2v}-*/` are intentionally untouched per the Phase 1 plan; they pick up the new code on regeneration.

## Test plan

- [x] `pytest .claude/skills/mcp-async-skill/scripts/tests/ -q` → 299 passed
- [x] `rg` audit for leftover private attribute access / single-arg setter calls → clean
- [x] docs match implementation (mirror keys come from `sorted(limits.keys())[0]` = `i2i` — verified in code, docs, and `test_includes_legacy_mirror_keys_for_old_dashboard`)
- [ ] Manual: PATCH a single per-category value via `curl` and confirm only that category changes (covered by `TestPatchNewForm`, but worth a smoke test on a real worker before tag)
- [ ] Manual: PATCH legacy form via `curl` and confirm `_legacy_warning` appears (covered by `TestPatchLegacyForm`)
- [ ] Manual: load a `lazy-v2.10.x` `queue_config.json` and confirm worker starts with one DEPRECATED log line (covered by `TestUpgradeCompat`)

## Out of scope (Phase 1 follow-ups)

- **#62** — worker version handshake (`X-Worker-Version` + `GET /api/version`) so users who overwrite-install `lazy-v2.11.0` while a `lazy-v2.10.x` worker is still running get a clear stderr warning about the version skew.
- **#63** — `PRAGMA user_version` migration foundation in `db.py`.

These are independent commits in the same `lazy-v2.11.0` release train per `.claude/worktrees/PHASE1_PLAN_v3.md`.

## Reviewing this PR

Suggested commit-by-commit reading order:

1. `68549b6` chore: gitignore `.claude/worktrees/` — trivial
2. `3cb89b8` fix: 6 silent test failures — read this first to understand which baseline behavior is now considered correct
3. `204b88a` feat: per-category implementation — the actual PR #59 content
4. `b3b8136` test: per-category + worker config (37 + 18 = 55 tests)
5. `f852add` test: unknown endpoint dispatch + legacy timestamp parse (6 tests, from review)
6. `8409d0c` docs: docs/category-limits.md + README + CHANGELOG (from review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)