### PR TITLE
feat(queue): custom_groups for endpoint-pattern rate limiting + LimiterStateMixin (#60)

### DIFF
--- a/.claude/skills/mcp-async-skill/scripts/generate_skill.py
+++ b/.claude/skills/mcp-async-skill/scripts/generate_skill.py
@@ -1018,11 +1018,45 @@ def generate_queue_config(endpoint: str) -> dict:
             },
         },
         # PR4 (#60): user-defined endpoint groups with their own
-        # rate limits. Empty by default; populate to throttle a
-        # subset of endpoints (e.g. high-cost models) more strictly
-        # than their parent category. See docs/custom-groups.md for
-        # the schema and examples.
-        "custom_groups": {},
+        # rate limits. The defaults below cover Bytedance Seedance
+        # v2.0 video models, which the upstream MCP service throttles
+        # separately from their parent t2v / i2v / r2v categories.
+        # The URL prefixes (`t2v_sd2`, `i2v_sd2`, `r2v_sd2`) are
+        # service-specific and intentionally not in the standard
+        # category list, so without these groups the dispatcher would
+        # treat the endpoints as "unknown" and skip rate-limit
+        # accounting entirely.
+        # See docs/custom-groups.md for the schema and how to add
+        # / remove / tune groups.
+        "custom_groups": {
+            "t2v_sd2": {
+                "endpoints": [
+                    "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0",
+                    "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0-fast",
+                ],
+                "max_inflight": 1,
+                "min_interval": 10,
+                "exhaust_cooldown": 3600,
+            },
+            "i2v_sd2": {
+                "endpoints": [
+                    "https://kamui-code.ai/i2v_sd2/fal/bytedance/seedance-v2.0",
+                    "https://kamui-code.ai/i2v_sd2/fal/bytedance/seedance-v2.0-fast",
+                ],
+                "max_inflight": 1,
+                "min_interval": 10,
+                "exhaust_cooldown": 3600,
+            },
+            "r2v_sd2": {
+                "endpoints": [
+                    "https://kamui-code.ai/r2v_sd2/fal/bytedance/seedance-v2.0-reference",
+                    "https://kamui-code.ai/r2v_sd2/fal/bytedance/seedance-v2.0-fast-reference",
+                ],
+                "max_inflight": 1,
+                "min_interval": 10,
+                "exhaust_cooldown": 3600,
+            },
+        },
     }
 
 

--- a/.claude/skills/mcp-async-skill/scripts/generate_skill.py
+++ b/.claude/skills/mcp-async-skill/scripts/generate_skill.py
@@ -1017,6 +1017,12 @@ def generate_queue_config(endpoint: str) -> dict:
                 "i2v": dict(per_cat_default),
             },
         },
+        # PR4 (#60): user-defined endpoint groups with their own
+        # rate limits. Empty by default; populate to throttle a
+        # subset of endpoints (e.g. high-cost models) more strictly
+        # than their parent category. See docs/custom-groups.md for
+        # the schema and examples.
+        "custom_groups": {},
     }
 
 

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/category_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/category_limiter.py
@@ -10,21 +10,32 @@ Manages per-category (t2i, i2i, t2v, i2v) dispatch gating with
 - Immediate pause with detailed reason on non-429 submit errors
 - Manual pause/resume with category state reporting
 
-Each category has its own `max_inflight`, `min_interval`, `exhaust_cooldown`
-configured via the `limits` mapping. Categories or keys not in `limits`
-fall back to module-level hardcoded defaults (this is a safety net for
-config typos; the canonical schema fully populates `limits`).
+Each category has its own `max_inflight`, `min_interval`,
+`exhaust_cooldown` configured via the `limits` mapping. Categories or
+keys not in `limits` fall back to module-level hardcoded defaults
+(this is a safety net for config typos; the canonical schema fully
+populates `limits`).
 
-429 errors trigger a cooldown but do NOT auto-pause the category.
-The job is returned to pending and retried after the cooldown expires.
+429 errors trigger a cooldown but do NOT auto-pause the category. The
+job is returned to pending and retried after the cooldown expires.
 Only non-429 errors (which consume server quota) trigger an immediate
 category pause to prevent further quota waste.
+
+Refactor note (PR4 / #60)
+-------------------------
+
+Inflight / cooldown / pause / 429-counter primitives moved into
+:class:`~job_queue.limiter_state.LimiterStateMixin` so the same
+state machine can back :class:`~job_queue.custom_group_limiter.CustomGroupLimiter`
+without duplication. CategoryLimiter retains its public API
+(``can_submit``, ``acquire_inflight``, ``release_inflight``,
+``set_max_inflight``, etc.) verbatim — see ``test_category_limiter.py``
+for the contract.
 """
 import logging
-import threading
-import time
-from datetime import datetime, timezone
 from urllib.parse import urlparse
+
+from .limiter_state import LimiterStateMixin
 
 logger = logging.getLogger(__name__)
 
@@ -34,15 +45,25 @@ DEFAULT_ALIASES: dict[str, str] = {"r2i": "i2i", "r2v": "i2v"}
 
 # Hardcoded fallback values for categories / keys missing from `limits`.
 # The canonical schema is to fully populate `limits.{cat}.{key}` for each
-# known category. These defaults exist only as a safety net for config typos
-# and for unit-test convenience.
+# known category. These defaults exist only as a safety net for config
+# typos and for unit-test convenience.
 HARDCODED_DEFAULT_MAX_INFLIGHT: int = 1
 HARDCODED_DEFAULT_MIN_INTERVAL: float = 1.0
 HARDCODED_DEFAULT_EXHAUST_COOLDOWN: float = 3600.0
 
 
-class CategoryLimiter:
-    """Category limiter with per-category inflight, cooldown, and pause control."""
+class CategoryLimiter(LimiterStateMixin):
+    """Category limiter with per-category inflight, cooldown, and pause control.
+
+    Inherits the inflight / cooldown / pause primitives from
+    :class:`LimiterStateMixin`. CategoryLimiter itself owns:
+
+    * The set of valid categories (``_categories``) + alias map
+    * The per-category limit dicts (``_max_inflight`` / ``_min_interval``
+      / ``_exhaust_cooldown``)
+    * URL-to-category extraction (``extract_category``)
+    * Legacy schema migration with one-shot deprecation warning
+    """
 
     def __init__(self, config: dict | None = None):
         config = config or {}
@@ -54,7 +75,9 @@ class CategoryLimiter:
         else:
             # Legacy: extract from "limits" keys if present, else use defaults
             limits_block = config.get("limits", None)
-            self._categories = set(limits_block.keys()) if limits_block else set(KNOWN_CATEGORIES)
+            self._categories = (
+                set(limits_block.keys()) if limits_block else set(KNOWN_CATEGORIES)
+            )
 
         self._aliases: dict[str, str] = {
             **DEFAULT_ALIASES,
@@ -68,19 +91,13 @@ class CategoryLimiter:
 
         legacy_used = self._load_limits_from_config(config)
 
-        # ---- Pause / runtime state ----
-        self._paused: set[str] = set()
-        self._pause_reason: dict[str, dict] = {}
-        self._last_submit: dict[str, float] = {}
-        self._inflight: dict[str, int] = {}
-        self._exhaust_time: dict[str, float] = {}
-        self._consecutive_429: dict[str, int] = {}
+        # ---- Pause / runtime state (provided by LimiterStateMixin) ----
+        self._init_state()
 
-        self._lock = threading.Lock()
-
-        # v3 fix #9: deprecation warning fires once per CategoryLimiter instance
-        # (not process-globally). Multiple workers / multiple limiters each emit
-        # their own warning, which is intentional for visibility.
+        # PR1 fix #9: deprecation warning fires once per CategoryLimiter
+        # instance (not process-globally). Multiple workers / multiple
+        # limiters each emit their own warning, which is intentional for
+        # visibility.
         if legacy_used:
             logger.warning(
                 "[CategoryLimiter] (instance %s) DEPRECATED: flat "
@@ -97,8 +114,7 @@ class CategoryLimiter:
 
     def _load_limits_from_config(self, config: dict) -> bool:
         """Populate per-category dicts from config. Returns True if legacy
-        flat schema was used (so caller can emit a deprecation warning).
-        """
+        flat schema was used (so caller can emit a deprecation warning)."""
         new_limits = config.get("limits", None)
         legacy_max = config.get("max_category_inflight", None)
         legacy_interval = config.get("min_interval", None)
@@ -121,7 +137,11 @@ class CategoryLimiter:
         # ---- Legacy schema: flat `max_category_inflight` etc. ----
         # Fan out the legacy scalar value to ALL configured categories that
         # don't already have a per-category override. The new schema wins.
-        if legacy_max is not None or legacy_interval is not None or legacy_cooldown is not None:
+        if (
+            legacy_max is not None
+            or legacy_interval is not None
+            or legacy_cooldown is not None
+        ):
             legacy_used = True
             for cat in self._categories:
                 if legacy_max is not None and cat not in self._max_inflight:
@@ -233,7 +253,8 @@ class CategoryLimiter:
                 return False
 
             # Enforce minimum interval between submits
-            now = time.monotonic()
+            import time as _time
+            now = _time.monotonic()
             min_interval = self._min_interval.get(category, HARDCODED_DEFAULT_MIN_INTERVAL)
             if (now - self._last_submit.get(category, 0.0)) < min_interval:
                 return False
@@ -243,37 +264,36 @@ class CategoryLimiter:
             if self._inflight.get(category, 0) >= max_inflight:
                 return False
 
-            # Cooldown check (429 rolling window)
-            exhaust_at = self._exhaust_time.get(category, 0.0)
-            if exhaust_at > 0:
-                cooldown = self._exhaust_cooldown.get(
-                    category, HARDCODED_DEFAULT_EXHAUST_COOLDOWN
+            # Cooldown check (429 rolling window) — uses mixin helper
+            cooldown = self._exhaust_cooldown.get(
+                category, HARDCODED_DEFAULT_EXHAUST_COOLDOWN
+            )
+            if not self._check_cooldown_locked(category, cooldown, now):
+                return False
+            # If the cooldown just expired the helper logged nothing; preserve
+            # the legacy info-log here for parity with previous behaviour.
+            if category not in self._exhaust_time and self._consecutive_429.get(category, 0) > 0:
+                # The cooldown was active and just expired; surface that fact.
+                logger.info(
+                    "[CategoryLimiter] Cooldown expired for %s, resuming", category,
                 )
-                if (now - exhaust_at) < cooldown:
-                    return False
-                else:
-                    # Cooldown expired
-                    self._exhaust_time.pop(category, None)
-                    logger.info(
-                        "[CategoryLimiter] Cooldown expired for %s, resuming",
-                        category,
-                    )
 
             return True
 
     def touch_submit(self, category: str | None):
-        """Update last-submit timestamp (for min_interval enforcement)."""
-        if category is None:
-            return
-        with self._lock:
-            self._last_submit[category] = time.monotonic()
+        """Update last-submit timestamp (for min_interval enforcement).
+
+        Overrides the mixin to keep the legacy-vs-new key acceptance
+        behaviour: unknown keys are silently ignored at the mixin level
+        already, but we still want to no-op for ``None``.
+        """
+        super().touch_submit(category)
 
     def record_success(self, category: str | None):
         """Record a successful submit — resets consecutive 429 counter."""
-        if category is None:
+        if category is None or category not in self._categories:
             return
-        with self._lock:
-            self._consecutive_429.pop(category, None)
+        super().record_success(category)
 
     # ------------------------------------------------------------------
     # Inflight control
@@ -290,14 +310,9 @@ class CategoryLimiter:
             return False
         with self._lock:
             if category not in self._categories:
-                # v3 fix #1: do not create inflight state for unknown
                 return False
             max_inflight = self._max_inflight.get(category, HARDCODED_DEFAULT_MAX_INFLIGHT)
-            current = self._inflight.get(category, 0)
-            if current >= max_inflight:
-                return False
-            self._inflight[category] = current + 1
-            return True
+            return self._acquire_inflight_locked(category, max_inflight)
 
     def release_inflight(self, category: str | None, success: bool):
         """Release an inflight slot."""
@@ -307,7 +322,7 @@ class CategoryLimiter:
             if category not in self._categories:
                 # No state to release for unknown (acquire_inflight returned False)
                 return
-            self._inflight[category] = max(0, self._inflight.get(category, 0) - 1)
+            self._release_inflight_locked(category)
 
     # ------------------------------------------------------------------
     # Runtime config setters
@@ -369,8 +384,12 @@ class CategoryLimiter:
             limits = {}
             for cat in sorted(self._categories):
                 limits[cat] = {
-                    "max_inflight": self._max_inflight.get(cat, HARDCODED_DEFAULT_MAX_INFLIGHT),
-                    "min_interval": self._min_interval.get(cat, HARDCODED_DEFAULT_MIN_INTERVAL),
+                    "max_inflight": self._max_inflight.get(
+                        cat, HARDCODED_DEFAULT_MAX_INFLIGHT
+                    ),
+                    "min_interval": self._min_interval.get(
+                        cat, HARDCODED_DEFAULT_MIN_INTERVAL
+                    ),
                     "exhaust_cooldown": self._exhaust_cooldown.get(
                         cat, HARDCODED_DEFAULT_EXHAUST_COOLDOWN
                     ),
@@ -378,17 +397,14 @@ class CategoryLimiter:
             return {"limits": limits}
 
     # ------------------------------------------------------------------
-    # 429 handling (cooldown only — no auto-pause)
+    # 429 / pause overrides — restrict to known categories only
     # ------------------------------------------------------------------
 
     def force_cooldown(self, category: str | None):
         """Start rolling cooldown for the category (on 429)."""
-        if category is None:
+        if category is None or category not in self._categories:
             return
-        with self._lock:
-            if category not in self._categories:
-                return
-            self._exhaust_time[category] = time.monotonic()
+        super().force_cooldown(category)
 
     def record_429(self, category: str | None):
         """Increment consecutive 429 counter (informational only).
@@ -397,23 +413,9 @@ class CategoryLimiter:
         The cooldown from ``force_cooldown`` is sufficient — once it expires,
         the dispatcher will automatically retry pending jobs.
         """
-        if category is None:
+        if category is None or category not in self._categories:
             return
-        with self._lock:
-            if category not in self._categories:
-                return
-            count = self._consecutive_429.get(category, 0) + 1
-            self._consecutive_429[category] = count
-            if count % 10 == 0:
-                logger.info(
-                    "[CategoryLimiter] %s has hit %d consecutive 429s "
-                    "(cooldown handles retry automatically)",
-                    category, count,
-                )
-
-    # ------------------------------------------------------------------
-    # Error-triggered pause (non-429 only)
-    # ------------------------------------------------------------------
+        super().record_429(category)
 
     def pause_with_reason(
         self,
@@ -425,64 +427,40 @@ class CategoryLimiter:
         endpoint: str = "",
     ):
         """Pause category due to an error. Stores detailed reason."""
-        if category is None:
+        if category is None or category not in self._categories:
             return
-        with self._lock:
-            if category not in self._categories:
-                return
-            self._paused.add(category)
-            self._pause_reason[category] = {
-                "reason": reason,
-                "status_code": status_code,
-                "error_detail": error_detail[:2000],
-                "job_id": job_id,
-                "endpoint": endpoint,
-                "paused_at": datetime.now(timezone.utc).isoformat(),
-            }
-        logger.warning(
-            "[CategoryLimiter] Paused %s: %s (HTTP %s) — %s",
-            category, reason, status_code, error_detail[:200],
+        super().pause_with_reason(
+            category,
+            reason,
+            status_code=status_code,
+            error_detail=error_detail,
+            job_id=job_id,
+            endpoint=endpoint,
         )
 
     # ------------------------------------------------------------------
-    # Manual pause / resume
+    # Manual pause / resume — keep legacy method names for back-compat
     # ------------------------------------------------------------------
 
     def pause_category(self, category: str):
-        """Manually pause a category. Pending jobs stay in queue."""
-        with self._lock:
-            if category not in self._categories:
-                return
-            self._paused.add(category)
-            self._pause_reason[category] = {
-                "reason": "manual",
-                "paused_at": datetime.now(timezone.utc).isoformat(),
-            }
+        """Manually pause a category. Pending jobs stay in queue.
+
+        Legacy name retained from lazy-v2.10.x; delegates to the mixin's
+        ``pause_key`` after a known-category guard.
+        """
+        if category not in self._categories:
+            return
+        self.pause_key(category)
 
     def resume_category(self, category: str):
-        """Remove pause, clear reason and consecutive 429 counter."""
-        with self._lock:
-            if category not in self._categories:
-                return
-            self._paused.discard(category)
-            self._pause_reason.pop(category, None)
-            self._consecutive_429.pop(category, None)
-            # Also clear cooldown so dispatch resumes immediately
-            self._exhaust_time.pop(category, None)
+        """Remove pause, clear reason and consecutive 429 counter.
 
-    def is_paused(self, category: str | None) -> bool:
-        """Return True if *category* is paused."""
-        if category is None:
-            return False
-        with self._lock:
-            return category in self._paused
-
-    def get_pause_reason(self, category: str | None) -> dict | None:
-        """Return pause reason dict, or None if not paused."""
-        if category is None:
-            return None
-        with self._lock:
-            return self._pause_reason.get(category)
+        Legacy name retained from lazy-v2.10.x; delegates to the mixin's
+        ``resume_key`` after a known-category guard.
+        """
+        if category not in self._categories:
+            return
+        self.resume_key(category)
 
     # ------------------------------------------------------------------
     # Status reporting
@@ -494,17 +472,18 @@ class CategoryLimiter:
         Each category's `max_inflight` reflects its per-category value
         (v3 change: was a single shared value in lazy-v2.10.x).
         """
+        import time as _time
         with self._lock:
-            now = time.monotonic()
+            now = _time.monotonic()
             result = {}
             for cat in sorted(self._categories):
                 exhaust_at = self._exhaust_time.get(cat, 0.0)
                 cooldown = self._exhaust_cooldown.get(
                     cat, HARDCODED_DEFAULT_EXHAUST_COOLDOWN
                 )
-                cooldown_remaining = max(
-                    0.0, cooldown - (now - exhaust_at)
-                ) if exhaust_at > 0 else 0.0
+                cooldown_remaining = (
+                    max(0.0, cooldown - (now - exhaust_at)) if exhaust_at > 0 else 0.0
+                )
 
                 entry: dict = {
                     "paused": cat in self._paused,

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/category_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/category_limiter.py
@@ -264,16 +264,22 @@ class CategoryLimiter(LimiterStateMixin):
             if self._inflight.get(category, 0) >= max_inflight:
                 return False
 
-            # Cooldown check (429 rolling window) — uses mixin helper
+            # Cooldown check (429 rolling window) — uses mixin helper.
+            # Capture whether a cooldown was active BEFORE the helper
+            # call so we can log exactly once on the transition from
+            # active → expired. Without the snapshot the condition
+            # ``category not in self._exhaust_time`` would be true on
+            # every call after the cooldown wore off, flooding the log
+            # until something else (e.g. record_success) cleared
+            # `_consecutive_429`.
             cooldown = self._exhaust_cooldown.get(
                 category, HARDCODED_DEFAULT_EXHAUST_COOLDOWN
             )
+            had_active_cooldown = category in self._exhaust_time
             if not self._check_cooldown_locked(category, cooldown, now):
                 return False
-            # If the cooldown just expired the helper logged nothing; preserve
-            # the legacy info-log here for parity with previous behaviour.
-            if category not in self._exhaust_time and self._consecutive_429.get(category, 0) > 0:
-                # The cooldown was active and just expired; surface that fact.
+            if had_active_cooldown and category not in self._exhaust_time:
+                # The cooldown was active up to this call and just expired.
                 logger.info(
                     "[CategoryLimiter] Cooldown expired for %s, resuming", category,
                 )
@@ -283,10 +289,15 @@ class CategoryLimiter(LimiterStateMixin):
     def touch_submit(self, category: str | None):
         """Update last-submit timestamp (for min_interval enforcement).
 
-        Overrides the mixin to keep the legacy-vs-new key acceptance
-        behaviour: unknown keys are silently ignored at the mixin level
-        already, but we still want to no-op for ``None``.
+        Overrides the mixin to enforce the "unknown keys create no
+        state" contract that ``can_submit`` / ``acquire_inflight`` /
+        ``release_inflight`` already follow. Without this guard the
+        mixin would happily insert an entry into ``_last_submit`` for
+        an arbitrary string, growing the dict unboundedly if a caller
+        ever mistakenly fed it raw endpoint URLs.
         """
+        if category is None or category not in self._categories:
+            return
         super().touch_submit(category)
 
     def record_success(self, category: str | None):

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/custom_group_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/custom_group_limiter.py
@@ -1,0 +1,394 @@
+# -*- coding: utf-8 -*-
+"""User-defined custom-group rate limiting (PR4 / #60).
+
+Categories (``t2i`` / ``i2i`` / ``t2v`` / ``i2v``) cover the common
+case but cannot express "throttle these specific endpoints together
+regardless of category". The upstream MCP service applies extra,
+narrower rate limits to certain high-cost models (e.g. video models
+priced higher than text-to-image), and we need to mirror that on the
+client.
+
+Schema in ``queue_config.json``::
+
+    {
+      "custom_groups": {
+        "premium-video": {
+          "endpoints": [
+            "https://kamui-code.ai/t2v/fal/veo3*",
+            "https://kamui-code.ai/i2v/fal/veo3*"
+          ],
+          "max_inflight": 1,
+          "min_interval": 30,
+          "exhaust_cooldown": 7200
+        }
+      }
+    }
+
+Endpoints are matched against ``endpoints`` patterns (fnmatch / glob
+syntax). On a match the dispatcher uses :class:`CustomGroupLimiter`
+INSTEAD of :class:`~job_queue.category_limiter.CategoryLimiter` for that
+endpoint — the matched group fully replaces category accounting (the
+endpoint is not double-counted against its category).
+
+When multiple groups would match the same endpoint, the first one in
+configuration order wins. Python 3.7+ guarantees dict insertion
+order is preserved, so the wire-format ordering is the user-visible
+ordering.
+
+The state machine (inflight, 429 cooldown, pause/resume) is provided
+by :class:`~job_queue.limiter_state.LimiterStateMixin`, the same one
+:class:`CategoryLimiter` uses. Bug fixes there fix both limiters at
+once.
+
+Unknown groups (PHASE1_PLAN_v3 fix #1)
+--------------------------------------
+
+``can_submit("unknown_group_name") == acquire_inflight(...) == False``,
+and **no inflight state is created**. This mirrors CategoryLimiter's
+behaviour so the dispatcher's ``_resolve_limiter()`` (PR4) sees a
+consistent contract regardless of which limiter it picked.
+"""
+from __future__ import annotations
+
+import fnmatch
+import logging
+import time
+from datetime import datetime, timezone
+
+from .limiter_state import LimiterStateMixin
+
+logger = logging.getLogger(__name__)
+
+
+# Hardcoded fallback values, mirroring CategoryLimiter's HARDCODED_DEFAULT_*.
+# These exist as a safety net for config typos; the canonical schema
+# requires every group to specify its own values explicitly.
+HARDCODED_DEFAULT_MAX_INFLIGHT: int = 1
+HARDCODED_DEFAULT_MIN_INTERVAL: float = 1.0
+HARDCODED_DEFAULT_EXHAUST_COOLDOWN: float = 3600.0
+
+
+# Sentinel for the match cache: distinguishes "key not yet computed"
+# from "computed and known to match no group". (PHASE1_PLAN_v3 fix #13)
+_SENTINEL: object = object()
+
+
+class CustomGroupLimiter(LimiterStateMixin):
+    """Limiter for user-defined endpoint groups.
+
+    See module docstring for the wire format. The relevant constructor
+    contract is::
+
+        CustomGroupLimiter({"group_name": {
+            "endpoints": ["pattern1", "pattern2"],
+            "max_inflight": int,
+            "min_interval": float,        # optional
+            "exhaust_cooldown": float,    # optional
+        }})
+
+    or, with a top-level ``custom_groups`` wrapper::
+
+        CustomGroupLimiter({"custom_groups": { ... }})
+
+    A bare ``CustomGroupLimiter()`` (no config / empty config) is a
+    no-op — every endpoint will return ``None`` from
+    :meth:`extract_group`, telling the dispatcher to fall through to
+    the category limiter.
+    """
+
+    def __init__(self, config: dict | None = None):
+        config = config or {}
+
+        # Allow either {"custom_groups": {...}} or the inner dict directly.
+        if "custom_groups" in config:
+            groups_block = config["custom_groups"] or {}
+        else:
+            groups_block = config
+
+        # Insertion order matters: first match wins (Python 3.7+).
+        self._groups: list[str] = []
+        self._patterns: dict[str, list[str]] = {}
+        self._max_inflight: dict[str, int] = {}
+        self._min_interval: dict[str, float] = {}
+        self._exhaust_cooldown: dict[str, float] = {}
+
+        if isinstance(groups_block, dict):
+            for name, spec in groups_block.items():
+                if not isinstance(spec, dict):
+                    logger.warning(
+                        "[CustomGroupLimiter] group %r: spec must be dict, ignoring",
+                        name,
+                    )
+                    continue
+                patterns = spec.get("endpoints")
+                if not isinstance(patterns, list) or not patterns:
+                    logger.warning(
+                        "[CustomGroupLimiter] group %r: 'endpoints' must be a "
+                        "non-empty list, ignoring", name,
+                    )
+                    continue
+
+                self._groups.append(name)
+                self._patterns[name] = list(patterns)
+                self._max_inflight[name] = int(
+                    spec.get("max_inflight", HARDCODED_DEFAULT_MAX_INFLIGHT)
+                )
+                self._min_interval[name] = float(
+                    spec.get("min_interval", HARDCODED_DEFAULT_MIN_INTERVAL)
+                )
+                self._exhaust_cooldown[name] = float(
+                    spec.get("exhaust_cooldown", HARDCODED_DEFAULT_EXHAUST_COOLDOWN)
+                )
+
+        # endpoint → group_name (or None) cache. Lock-protected per
+        # PHASE1_PLAN_v3 fix #13 so a future `_match_cache` writer can
+        # not race a reader.
+        self._match_cache: dict[str, str | None] = {}
+
+        self._init_state()
+
+    # ------------------------------------------------------------------
+    # Public read-only accessors
+    # ------------------------------------------------------------------
+
+    def get_groups(self) -> list[str]:
+        """Configured group names in declaration order."""
+        return list(self._groups)
+
+    def is_known_group(self, group: str | None) -> bool:
+        if group is None:
+            return False
+        return group in self._patterns
+
+    def get_max_inflight(self, group: str | None) -> int:
+        if group is None or group not in self._patterns:
+            return HARDCODED_DEFAULT_MAX_INFLIGHT
+        return self._max_inflight.get(group, HARDCODED_DEFAULT_MAX_INFLIGHT)
+
+    def get_min_interval(self, group: str | None) -> float:
+        if group is None or group not in self._patterns:
+            return HARDCODED_DEFAULT_MIN_INTERVAL
+        return self._min_interval.get(group, HARDCODED_DEFAULT_MIN_INTERVAL)
+
+    def get_exhaust_cooldown(self, group: str | None) -> float:
+        if group is None or group not in self._patterns:
+            return HARDCODED_DEFAULT_EXHAUST_COOLDOWN
+        return self._exhaust_cooldown.get(group, HARDCODED_DEFAULT_EXHAUST_COOLDOWN)
+
+    # ------------------------------------------------------------------
+    # Endpoint matching
+    # ------------------------------------------------------------------
+
+    def extract_group(self, endpoint: str) -> str | None:
+        """Match ``endpoint`` against the configured groups (fnmatch).
+
+        Returns the first matching group name in configuration order, or
+        ``None`` if no group matches. Results are cached for subsequent
+        calls with the same endpoint string.
+
+        Cache reads + writes happen under ``self._lock`` so concurrent
+        dispatcher threads cannot observe a half-populated cache entry.
+        """
+        if endpoint is None or not self._groups:
+            return None
+        with self._lock:
+            cached = self._match_cache.get(endpoint, _SENTINEL)
+            if cached is not _SENTINEL:
+                return cached  # type: ignore[return-value]
+            for name in self._groups:
+                for pat in self._patterns[name]:
+                    try:
+                        if fnmatch.fnmatchcase(endpoint, pat):
+                            self._match_cache[endpoint] = name
+                            return name
+                    except Exception:
+                        # Defensive: a malformed pattern should not crash
+                        # the dispatcher. Log once and continue.
+                        logger.warning(
+                            "[CustomGroupLimiter] fnmatch failed for "
+                            "pattern %r on endpoint %r", pat, endpoint,
+                            exc_info=True,
+                        )
+            self._match_cache[endpoint] = None
+            return None
+
+    # ------------------------------------------------------------------
+    # Submit gating (mirrors CategoryLimiter's contract)
+    # ------------------------------------------------------------------
+
+    def can_submit(self, group: str | None) -> bool:
+        if group is None:
+            return True  # category-less; dispatcher decides
+        with self._lock:
+            if group not in self._patterns:
+                return False
+            if group in self._paused:
+                return False
+
+            now = time.monotonic()
+            min_interval = self._min_interval.get(group, HARDCODED_DEFAULT_MIN_INTERVAL)
+            if (now - self._last_submit.get(group, 0.0)) < min_interval:
+                return False
+
+            max_inflight = self._max_inflight.get(group, HARDCODED_DEFAULT_MAX_INFLIGHT)
+            if self._inflight.get(group, 0) >= max_inflight:
+                return False
+
+            cooldown = self._exhaust_cooldown.get(group, HARDCODED_DEFAULT_EXHAUST_COOLDOWN)
+            if not self._check_cooldown_locked(group, cooldown, now):
+                return False
+
+            return True
+
+    def acquire_inflight(self, group: str | None) -> bool:
+        if group is None:
+            return False
+        with self._lock:
+            if group not in self._patterns:
+                return False
+            max_inflight = self._max_inflight.get(group, HARDCODED_DEFAULT_MAX_INFLIGHT)
+            return self._acquire_inflight_locked(group, max_inflight)
+
+    def release_inflight(self, group: str | None, success: bool):
+        if group is None:
+            return
+        with self._lock:
+            if group not in self._patterns:
+                return
+            self._release_inflight_locked(group)
+
+    # ------------------------------------------------------------------
+    # 429 / pause overrides — restrict to known groups
+    # ------------------------------------------------------------------
+
+    def force_cooldown(self, group: str | None):
+        if group is None or group not in self._patterns:
+            return
+        super().force_cooldown(group)
+
+    def record_429(self, group: str | None):
+        if group is None or group not in self._patterns:
+            return
+        super().record_429(group)
+
+    def record_success(self, group: str | None):
+        if group is None or group not in self._patterns:
+            return
+        super().record_success(group)
+
+    def pause_with_reason(
+        self,
+        group: str | None,
+        reason: str,
+        status_code: int | None = None,
+        error_detail: str = "",
+        job_id: str = "",
+        endpoint: str = "",
+    ):
+        if group is None or group not in self._patterns:
+            return
+        super().pause_with_reason(
+            group,
+            reason,
+            status_code=status_code,
+            error_detail=error_detail,
+            job_id=job_id,
+            endpoint=endpoint,
+        )
+
+    # ------------------------------------------------------------------
+    # Manual pause / resume
+    # ------------------------------------------------------------------
+
+    def pause_group(self, group: str):
+        """Manually pause a group. Pending jobs stay queued."""
+        if group not in self._patterns:
+            return
+        self.pause_key(group)
+
+    def resume_group(self, group: str):
+        """Resume a paused group + clear cooldown / consecutive-429."""
+        if group not in self._patterns:
+            return
+        self.resume_key(group)
+
+    # ------------------------------------------------------------------
+    # Runtime config setters (per-group)
+    # ------------------------------------------------------------------
+
+    def set_max_inflight(self, group: str, value: int):
+        with self._lock:
+            if group not in self._patterns:
+                logger.warning(
+                    "[CustomGroupLimiter] set_max_inflight: unknown group %r ignored",
+                    group,
+                )
+                return
+            self._max_inflight[group] = max(1, int(value))
+
+    def set_min_interval(self, group: str, value: float):
+        with self._lock:
+            if group not in self._patterns:
+                logger.warning(
+                    "[CustomGroupLimiter] set_min_interval: unknown group %r ignored",
+                    group,
+                )
+                return
+            self._min_interval[group] = max(0.0, float(value))
+
+    def set_exhaust_cooldown(self, group: str, value: float):
+        with self._lock:
+            if group not in self._patterns:
+                logger.warning(
+                    "[CustomGroupLimiter] set_exhaust_cooldown: unknown group %r ignored",
+                    group,
+                )
+                return
+            self._exhaust_cooldown[group] = max(0.0, float(value))
+
+    # ------------------------------------------------------------------
+    # Status reporting
+    # ------------------------------------------------------------------
+
+    def get_config(self) -> dict:
+        """Return current per-group config in the wire-format shape."""
+        with self._lock:
+            groups = {}
+            for name in self._groups:
+                groups[name] = {
+                    "endpoints": list(self._patterns[name]),
+                    "max_inflight": self._max_inflight[name],
+                    "min_interval": self._min_interval[name],
+                    "exhaust_cooldown": self._exhaust_cooldown[name],
+                }
+            return {"custom_groups": groups}
+
+    def get_all_status(self) -> dict:
+        """Return runtime status for every configured group."""
+        with self._lock:
+            now = time.monotonic()
+            result = {}
+            for name in self._groups:
+                exhaust_at = self._exhaust_time.get(name, 0.0)
+                cooldown = self._exhaust_cooldown.get(
+                    name, HARDCODED_DEFAULT_EXHAUST_COOLDOWN
+                )
+                cooldown_remaining = (
+                    max(0.0, cooldown - (now - exhaust_at)) if exhaust_at > 0 else 0.0
+                )
+
+                entry: dict = {
+                    "endpoints": list(self._patterns[name]),
+                    "paused": name in self._paused,
+                    "inflight": self._inflight.get(name, 0),
+                    "max_inflight": self._max_inflight[name],
+                    "min_interval": self._min_interval[name],
+                    "exhaust_cooldown": cooldown,
+                    "consecutive_429": self._consecutive_429.get(name, 0),
+                    "cooldown_remaining_s": round(cooldown_remaining, 1),
+                }
+                reason = self._pause_reason.get(name)
+                if reason:
+                    entry["pause_reason"] = reason
+                result[name] = entry
+            return result

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/custom_group_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/custom_group_limiter.py
@@ -261,6 +261,20 @@ class CustomGroupLimiter(LimiterStateMixin):
     # 429 / pause overrides — restrict to known groups
     # ------------------------------------------------------------------
 
+    def touch_submit(self, group: str | None):
+        """Update last-submit timestamp for ``min_interval`` enforcement.
+
+        Overrides the mixin to enforce the "unknown keys create no
+        state" contract that ``can_submit`` / ``acquire_inflight``
+        already follow. Without this guard the mixin would happily
+        insert an entry into ``_last_submit`` for an arbitrary string,
+        growing the dict unboundedly if a caller ever mistakenly fed
+        it raw endpoint URLs.
+        """
+        if group is None or group not in self._patterns:
+            return
+        super().touch_submit(group)
+
     def force_cooldown(self, group: str | None):
         if group is None or group not in self._patterns:
             return

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/dispatcher.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/dispatcher.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 from . import db
 from .category_limiter import CategoryLimiter
+from .custom_group_limiter import CustomGroupLimiter
 
 
 class QueueConfig:
@@ -50,6 +51,9 @@ class QueueConfig:
             )
 
         cfg.category_rate_limits = d.get("category_rate_limits", {})
+        # PR4 (#60): user-defined endpoint groups with their own
+        # rate limits, overriding category accounting on match.
+        cfg.custom_groups = d.get("custom_groups", {})
         cfg.stale_polling_timeout = float(
             d.get("stale_polling_timeout_seconds", 1800.0)
         )
@@ -93,6 +97,12 @@ class Dispatcher:
         self.category_limiter = CategoryLimiter(
             getattr(config, "category_rate_limits", None)
         )
+        # PR4 (#60): user-defined groups override category accounting on
+        # match. An empty group config (= no groups configured) leaves
+        # the category_limiter as the sole limiter.
+        self.group_limiter = CustomGroupLimiter(
+            getattr(config, "custom_groups", None)
+        )
         self._last_run_time: dict[str, float] = {}
         self._pause_until: dict[str, float] = {}
         self._endpoint_paused: set[str] = set()
@@ -100,6 +110,36 @@ class Dispatcher:
         self._pool = ThreadPoolExecutor(max_workers=max_workers)
         self._running = False
         self._thread: threading.Thread | None = None
+
+    def _resolve_limiter(self, endpoint: str):
+        """Pick the limiter responsible for ``endpoint``.
+
+        Returns ``(limiter, key)`` where:
+
+        * ``limiter`` is :class:`CustomGroupLimiter` when ``endpoint``
+          matches a configured custom group, otherwise
+          :class:`CategoryLimiter`, otherwise ``None``.
+        * ``key`` is the matched group name / extracted category /
+          ``None`` (truly unknown endpoint).
+
+        PR4 contract (PHASE1_PLAN_v3 fix #1 / #11): callers MUST treat
+        ``key=None`` (or ``limiter=None``) as "out of accounting scope"
+        and skip every rate-limit gate. The dispatcher does so for
+        category-less endpoints today and continues to do so for
+        endpoints that match no group AND no recognised category.
+
+        This is the single funnel through which dispatch / run paths
+        reach the rate limiters. The grep checklist in the PR4 PR body
+        verifies that no other call site touches ``self.category_limiter``
+        or ``self.group_limiter`` directly except the constructor.
+        """
+        group = self.group_limiter.extract_group(endpoint)
+        if group is not None:
+            return self.group_limiter, group
+        cat = self.category_limiter.extract_category(endpoint)
+        if cat is None:
+            return None, None
+        return self.category_limiter, cat
 
     def pause_endpoint(self, endpoint: str, seconds: float):
         """Suspend new dispatches to an endpoint for *seconds* seconds."""
@@ -136,21 +176,25 @@ class Dispatcher:
         Returns the number of jobs dispatched in this round.
         """
         dispatched = 0
-        dispatched_categories: set[str] = set()
+        # Track keys we have already dispatched against this round to
+        # avoid bursts across multiple endpoints sharing the same key
+        # (category or group). ``None`` keys are never inserted —
+        # category-less / unmatched endpoints have no shared accounting
+        # bucket, so each one can dispatch independently.
+        dispatched_keys: set[tuple[int, str]] = set()
 
-        # --- Phase 1: pending jobs (existing logic) ---
+        # --- Phase 1: pending jobs ---
         endpoints = self.store.get_pending_endpoints()
 
         for ep in endpoints:
-            # Check category limit
-            category = self.category_limiter.extract_category(ep)
-            if not self.category_limiter.can_submit(category):
-                continue
+            limiter, key = self._resolve_limiter(ep)
 
-            # Limit to one dispatch per category per round to avoid
-            # submit bursts across different endpoints in the same category
-            if category is not None and category in dispatched_categories:
-                continue
+            # Limiter / key gating: only meaningful when we have one.
+            if limiter is not None and key is not None:
+                if not limiter.can_submit(key):
+                    continue
+                if (id(limiter), key) in dispatched_keys:
+                    continue
 
             # Check endpoint pause (non-429 error pause)
             if ep in self._endpoint_paused:
@@ -178,22 +222,24 @@ class Dispatcher:
 
             # Dispatch as many pending jobs as slots allow
             while available_slots > 0:
-                # Re-check category limit before each dispatch
-                if not self.category_limiter.can_submit(category):
-                    break
+                # Re-check limiter before each dispatch (only when applicable)
+                if limiter is not None and key is not None:
+                    if not limiter.can_submit(key):
+                        break
 
                 job = self.store.get_oldest_pending(ep)
                 if job is None:
                     break
 
                 self.store.update_status(job["id"], "running")
-                self.category_limiter.touch_submit(category)
+                if limiter is not None and key is not None:
+                    limiter.touch_submit(key)
                 self._last_run_time[ep] = time.monotonic()
                 self._pool.submit(self._run_job, job)
                 dispatched += 1
                 available_slots -= 1
-                if category is not None:
-                    dispatched_categories.add(category)
+                if limiter is not None and key is not None:
+                    dispatched_keys.add((id(limiter), key))
 
                 # After first dispatch, re-check interval for subsequent jobs
                 if min_interval > 0:
@@ -203,9 +249,9 @@ class Dispatcher:
         recovering_endpoints = self.store.get_recovering_endpoints()
 
         for ep in recovering_endpoints:
-            # Check category pause (but NOT quota — recovery doesn't consume a new submit)
-            category = self.category_limiter.extract_category(ep)
-            if category is not None and self.category_limiter.is_paused(category):
+            # Check pause (but NOT quota — recovery doesn't consume a new submit)
+            limiter, key = self._resolve_limiter(ep)
+            if limiter is not None and key is not None and limiter.is_paused(key):
                 continue
 
             # Check endpoint pause
@@ -267,17 +313,26 @@ class Dispatcher:
         return json.dumps(detail, ensure_ascii=False)
 
     def _run_job(self, job: dict):
-        """Execute a job via the injected executor."""
-        category = self.category_limiter.extract_category(job["endpoint"])
+        """Execute a job via the injected executor.
+
+        Resolves the limiter once via :meth:`_resolve_limiter` and uses
+        it for inflight acquire/release, 429 cooldown, and success/error
+        reporting. ``limiter is None`` (unknown endpoint with no
+        category and no group match) means "no rate-limit accounting" —
+        the executor still runs, but no inflight state is created and
+        no per-key cooldown is applied. The endpoint-level
+        ``pause_endpoint`` cooldown still fires for safety.
+        """
+        endpoint = job["endpoint"]
+        limiter, key = self._resolve_limiter(endpoint)
         acquired = (
-            self.category_limiter.acquire_inflight(category)
-            if category else False
+            limiter.acquire_inflight(key) if (limiter is not None and key is not None) else False
         )
         had_error = False
         try:
             self.job_executor(job)
-            if category:
-                self.category_limiter.record_success(category)
+            if limiter is not None and key is not None:
+                limiter.record_success(key)
         except Exception as e:
             had_error = True
             resp = getattr(e, "response", None)
@@ -300,16 +355,19 @@ class Dispatcher:
 
             if status_code == 429:
                 # 429 does NOT consume server quota → requeue + cooldown
-                if category:
-                    self.category_limiter.force_cooldown(category)
-                    self.category_limiter.record_429(category)
-                # Always set endpoint-level cooldown (covers unknown categories).
-                # v3 fix M3: use the public per-category getter — for unknown
-                # categories this returns the hardcoded default cooldown.
-                self.pause_endpoint(
-                    job["endpoint"],
-                    self.category_limiter.get_exhaust_cooldown(category),
-                )
+                if limiter is not None and key is not None:
+                    limiter.force_cooldown(key)
+                    limiter.record_429(key)
+                # Always set endpoint-level cooldown. For an unknown
+                # endpoint we fall back to CategoryLimiter's hardcoded
+                # default — there's no group/category-specific value to
+                # use, but we still want SOMETHING so we don't
+                # immediately retry a 429.
+                if limiter is not None and key is not None:
+                    cooldown = limiter.get_exhaust_cooldown(key)
+                else:
+                    cooldown = self.category_limiter.get_exhaust_cooldown(None)
+                self.pause_endpoint(endpoint, cooldown)
                 self.store.update_status(
                     job["id"], "pending",
                     error=(
@@ -323,7 +381,6 @@ class Dispatcher:
                 self.store.update_status(
                     job["id"], "failed", error=error_detail
                 )
-                endpoint = job["endpoint"]
                 self._endpoint_paused.add(endpoint)
                 self._endpoint_pause_reason[endpoint] = {
                     "reason": "submit_error",
@@ -337,10 +394,8 @@ class Dispatcher:
                     endpoint, status_code,
                 )
         finally:
-            if acquired:
-                self.category_limiter.release_inflight(
-                    category, success=not had_error
-                )
+            if acquired and limiter is not None and key is not None:
+                limiter.release_inflight(key, success=not had_error)
 
     def start(self):
         """Start the dispatcher loop in a background thread."""

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/limiter_state.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/limiter_state.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+"""Shared inflight / cooldown / pause / 429-counter state for rate limiters.
+
+Used by both :class:`~job_queue.category_limiter.CategoryLimiter`
+(``key=category``, e.g. ``"t2v"``) and
+:class:`~job_queue.custom_group_limiter.CustomGroupLimiter`
+(``key=group_name``, e.g. ``"premium-video"``).
+
+Centralising these primitives means a bug fix or new behaviour (e.g.
+exponential backoff on consecutive 429s) only needs to be written
+once, and the "unknown key is out of scope" rule that PR1 (#59)
+established for CategoryLimiter applies uniformly to CustomGroupLimiter
+too.
+
+Design contract
+---------------
+
+The mixin owns the following per-key state:
+
+* ``_inflight``: ``dict[str, int]`` — current concurrent submits per key
+* ``_exhaust_time``: ``dict[str, float]`` — ``time.monotonic()`` when a
+  429 cooldown started for the key (rolling window)
+* ``_paused``: ``set[str]`` — keys explicitly paused (manual or after
+  a non-429 error)
+* ``_pause_reason``: ``dict[str, dict]`` — diagnostic info for paused keys
+* ``_consecutive_429``: ``dict[str, int]`` — informational counter
+* ``_last_submit``: ``dict[str, float]`` — for ``min_interval`` enforcement
+* ``_lock``: ``threading.Lock`` — guards every mutation above
+
+The mixin does NOT own per-key configured limits (``max_inflight``,
+``min_interval``, ``exhaust_cooldown``). Those are subclass concerns
+because the lookup keys (category vs group) and the schemas
+(``limits.{cat}`` vs ``custom_groups.{name}``) differ. Subclasses
+read their own per-key limit and pass the integer to
+:meth:`_acquire_inflight_locked` / :meth:`_check_cooldown_locked`.
+
+Unknown keys (PHASE1_PLAN_v3 fix #1)
+------------------------------------
+
+Subclasses are expected to reject unknown keys at the top of their
+``can_submit`` / ``acquire_inflight`` overrides BEFORE calling into
+the mixin. The mixin trusts that anything reaching ``_*_locked``
+helpers is already a known key. This keeps unknown-key handling
+(and the "create no state" rule) at the subclass boundary where the
+"known set" lives.
+
+Init helper guard (PHASE1_PLAN_v3 fix M2)
+-----------------------------------------
+
+Subclasses MUST call :meth:`_init_state` from their ``__init__``. The
+mixin's mutators raise :class:`RuntimeError` if invoked before
+``_init_state`` so the failure mode is loud rather than the cryptic
+``AttributeError: '_lock'`` you'd otherwise get the first time a
+production code path calls ``acquire_inflight``.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+class LimiterStateMixin:
+    """Provides the per-key inflight / cooldown / pause primitives.
+
+    Subclass requirements:
+
+    * Override ``__init__`` and call ``self._init_state()`` somewhere
+      inside it.
+    * Override ``can_submit(key)`` / ``acquire_inflight(key)`` /
+      ``release_inflight(key, success)`` — those need the subclass's
+      "known key set" plus its per-key configured limit lookups, which
+      the mixin doesn't have.
+
+    Mixin-provided methods (call directly on the subclass):
+
+    * :meth:`force_cooldown` / :meth:`record_429` / :meth:`record_success`
+    * :meth:`is_paused` / :meth:`pause_with_reason` / :meth:`pause_key`
+      / :meth:`resume_key` / :meth:`get_pause_reason`
+    * :meth:`touch_submit`
+    """
+
+    # --- Initialisation -----------------------------------------------
+
+    def _init_state(self) -> None:
+        """Allocate the per-key state dicts. Must be called from
+        subclass ``__init__``."""
+        self._inflight: dict[str, int] = {}
+        self._exhaust_time: dict[str, float] = {}
+        self._paused: set[str] = set()
+        self._pause_reason: dict[str, dict] = {}
+        self._consecutive_429: dict[str, int] = {}
+        self._last_submit: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def _ensure_state_initialised(self) -> None:
+        """Sanity guard: raise RuntimeError if a mutator is called
+        before ``_init_state``.
+
+        This protects against a future subclass forgetting the init
+        call. Without it, the first ``acquire_inflight`` would raise
+        ``AttributeError: '_lock'`` at an unexpected place in the
+        dispatch path, which is hard to diagnose."""
+        if not hasattr(self, "_lock"):
+            raise RuntimeError(
+                f"{type(self).__name__} forgot to call _init_state() "
+                f"in __init__. LimiterStateMixin requires explicit "
+                f"state initialisation."
+            )
+
+    # --- Lock-protected primitives (caller must hold self._lock) ------
+
+    def _acquire_inflight_locked(self, key: str, max_inflight: int) -> bool:
+        """Try to bump the per-key inflight counter. Must be called
+        inside ``self._lock``."""
+        current = self._inflight.get(key, 0)
+        if current >= max_inflight:
+            return False
+        self._inflight[key] = current + 1
+        return True
+
+    def _release_inflight_locked(self, key: str) -> None:
+        """Decrement the per-key inflight counter, never below zero.
+        Must be called inside ``self._lock``."""
+        self._inflight[key] = max(0, self._inflight.get(key, 0) - 1)
+
+    def _check_cooldown_locked(
+        self, key: str, cooldown_seconds: float, now: float | None = None,
+    ) -> bool:
+        """Return True when the per-key 429 cooldown has expired (or
+        was never set). Side effect: clears the exhaust_time entry on
+        expiry so subsequent calls return True without re-evaluating.
+
+        Must be called inside ``self._lock``."""
+        exhaust_at = self._exhaust_time.get(key, 0.0)
+        if exhaust_at == 0:
+            return True
+        if now is None:
+            now = time.monotonic()
+        if (now - exhaust_at) >= cooldown_seconds:
+            self._exhaust_time.pop(key, None)
+            return True
+        return False
+
+    # --- 429 / submit-tracking ----------------------------------------
+
+    def force_cooldown(self, key: str) -> None:
+        """Start (or restart) the rolling 429 cooldown for ``key``.
+
+        ``key=None`` is a no-op so dispatcher code can pass through
+        ``extract_*`` results unconditionally.
+        """
+        if key is None:
+            return
+        self._ensure_state_initialised()
+        with self._lock:
+            self._exhaust_time[key] = time.monotonic()
+
+    def record_429(self, key: str) -> None:
+        """Increment the consecutive-429 counter (informational only —
+        cooldown handles the actual throttling). Logs every 10."""
+        if key is None:
+            return
+        self._ensure_state_initialised()
+        with self._lock:
+            count = self._consecutive_429.get(key, 0) + 1
+            self._consecutive_429[key] = count
+            if count and count % 10 == 0:
+                logger.info(
+                    "[%s] %s has hit %d consecutive 429s "
+                    "(cooldown handles retry automatically)",
+                    type(self).__name__, key, count,
+                )
+
+    def record_success(self, key: str) -> None:
+        """Reset the consecutive-429 counter after a successful submit."""
+        if key is None:
+            return
+        self._ensure_state_initialised()
+        with self._lock:
+            self._consecutive_429.pop(key, None)
+
+    def touch_submit(self, key: str) -> None:
+        """Update the last-submit timestamp (for ``min_interval``)."""
+        if key is None:
+            return
+        self._ensure_state_initialised()
+        with self._lock:
+            self._last_submit[key] = time.monotonic()
+
+    # --- Pause / resume -----------------------------------------------
+
+    def is_paused(self, key: str | None) -> bool:
+        if key is None:
+            return False
+        self._ensure_state_initialised()
+        with self._lock:
+            return key in self._paused
+
+    def get_pause_reason(self, key: str | None) -> dict | None:
+        if key is None:
+            return None
+        self._ensure_state_initialised()
+        with self._lock:
+            r = self._pause_reason.get(key)
+            return dict(r) if r else None
+
+    def pause_with_reason(
+        self,
+        key: str | None,
+        reason: str,
+        status_code: int | None = None,
+        error_detail: str = "",
+        job_id: str = "",
+        endpoint: str = "",
+    ) -> None:
+        """Pause a key due to an error. Stores diagnostic info for
+        later inspection via the worker API."""
+        if key is None:
+            return
+        self._ensure_state_initialised()
+        with self._lock:
+            self._paused.add(key)
+            self._pause_reason[key] = {
+                "reason": reason,
+                "status_code": status_code,
+                "error_detail": (error_detail or "")[:2000],
+                "job_id": job_id,
+                "endpoint": endpoint,
+                "paused_at": datetime.now(timezone.utc).isoformat(),
+            }
+        logger.warning(
+            "[%s] Paused %s: %s (HTTP %s) — %s",
+            type(self).__name__, key, reason, status_code,
+            (error_detail or "")[:200],
+        )
+
+    def pause_key(self, key: str) -> None:
+        """Manually pause a key. Pending jobs stay queued."""
+        self._ensure_state_initialised()
+        with self._lock:
+            self._paused.add(key)
+            self._pause_reason[key] = {
+                "reason": "manual",
+                "paused_at": datetime.now(timezone.utc).isoformat(),
+            }
+
+    def resume_key(self, key: str) -> None:
+        """Remove pause + clear consecutive-429 + cooldown for ``key``."""
+        self._ensure_state_initialised()
+        with self._lock:
+            self._paused.discard(key)
+            self._pause_reason.pop(key, None)
+            self._consecutive_429.pop(key, None)
+            self._exhaust_time.pop(key, None)

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
@@ -159,11 +159,13 @@ class _RequestHandler(BaseHTTPRequestHandler):
         if self.path == "/api/stats":
             stats = app.store.get_stats_by_endpoint()
             cat_status = app.dispatcher.category_limiter.get_all_status()
+            grp_status = app.dispatcher.group_limiter.get_all_status()
             ep_pauses = app.dispatcher.get_all_endpoint_pauses()
             self._send_json(200, {
                 "server_time_utc": _utc_now_iso(),
                 "endpoints": stats,
                 "category_limits": cat_status,
+                "custom_groups": grp_status,
                 "endpoint_pauses": ep_pauses,
             })
             return
@@ -173,6 +175,17 @@ class _RequestHandler(BaseHTTPRequestHandler):
             self._send_json(200, {
                 "server_time_utc": _utc_now_iso(),
                 "categories": cat_status,
+            })
+            return
+
+        if self.path == "/api/groups":
+            # PR4 (#60): runtime status of every configured custom group
+            # — patterns, current inflight / cooldown / pause / 429
+            # counter. Empty dict when no group is configured.
+            grp_status = app.dispatcher.group_limiter.get_all_status()
+            self._send_json(200, {
+                "server_time_utc": _utc_now_iso(),
+                "groups": grp_status,
             })
             return
 
@@ -196,8 +209,13 @@ class _RequestHandler(BaseHTTPRequestHandler):
                     "exhaust_cooldown": first_cat.get("exhaust_cooldown"),
                 }
 
+            # PR4 (#60): expose custom_groups configuration alongside
+            # the category block. Empty dict when no group is configured.
+            grp_cfg = app.dispatcher.group_limiter.get_config()
+
             self._send_json(200, {
                 "category": {**cat_cfg, **legacy_compat},
+                "custom_groups": grp_cfg.get("custom_groups", {}),
                 "endpoint": {
                     "default_max_concurrent": app.dispatcher.config.default_max_concurrent,
                     "default_min_interval": app.dispatcher.config.default_min_interval,
@@ -308,6 +326,41 @@ class _RequestHandler(BaseHTTPRequestHandler):
             self._send_json(400, {"error": "Invalid category action. Use /api/categories/{category}/pause or /resume"})
             return
 
+        # PR4 (#60): custom group pause/resume — symmetric with the
+        # category endpoints above so the dashboard can use the same
+        # request shape for both.
+        if self.path.startswith("/api/groups/"):
+            parts = self.path.rstrip("/").split("/")
+            # /api/groups/{name}/{action}
+            if len(parts) == 5:
+                name = parts[3]
+                action = parts[4]
+                limiter = app.dispatcher.group_limiter
+                if not limiter.is_known_group(name):
+                    self._send_json(404, {
+                        "error": f"Unknown group: {name}",
+                        "available_groups": limiter.get_groups(),
+                    })
+                    return
+                if action == "pause":
+                    limiter.pause_group(name)
+                    self._send_json(200, {
+                        "group": name,
+                        "paused": True,
+                        "status": limiter.get_all_status().get(name, {}),
+                    })
+                    return
+                if action == "resume":
+                    limiter.resume_group(name)
+                    self._send_json(200, {
+                        "group": name,
+                        "paused": False,
+                        "status": limiter.get_all_status().get(name, {}),
+                    })
+                    return
+            self._send_json(400, {"error": "Invalid group action. Use /api/groups/{name}/pause or /resume"})
+            return
+
         if self.path == "/api/jobs":
             try:
                 body = json.loads(self._read_body())
@@ -348,12 +401,15 @@ class _RequestHandler(BaseHTTPRequestHandler):
 
             resp_data = {"job_id": job_id, "status": "pending"}
 
-            # Warn if the category is paused
-            limiter = app.dispatcher.category_limiter
-            cat = limiter.extract_category(endpoint)
-            if cat and limiter.is_paused(cat):
-                resp_data["warning"] = f"Category {cat} is paused"
-                reason = limiter.get_pause_reason(cat)
+            # Warn if the resolved limiter (group OR category) is paused.
+            # PR4 (#60): when an endpoint matches a custom group, the
+            # group takes over from the category — so the warning text
+            # should reflect what's actually gating the dispatch.
+            limiter, key = app.dispatcher._resolve_limiter(endpoint)
+            if limiter is not None and key is not None and limiter.is_paused(key):
+                kind = "Group" if limiter is app.dispatcher.group_limiter else "Category"
+                resp_data["warning"] = f"{kind} {key} is paused"
+                reason = limiter.get_pause_reason(key)
                 if reason:
                     resp_data["pause_reason"] = reason
 
@@ -470,6 +526,45 @@ class _RequestHandler(BaseHTTPRequestHandler):
                         setter(cat_name, v)
                         affected.append(cat_name)
                     applied[f"category.{key}"] = {"value": v, "affected": affected}
+
+            # PR4 (#60): per-group runtime tuning. Same per-key shape as
+            # category.limits.{cat}.{key} but rooted at the top level
+            # under `groups`. Unknown groups are rejected (vs unknown
+            # categories which are also rejected by limiter.set_*).
+            grp_block = body.get("groups", None)
+            if grp_block is not None and not isinstance(grp_block, dict):
+                rejected["groups"] = (
+                    f"must be object (got {type(grp_block).__name__})"
+                )
+                grp_block = None
+            if grp_block is not None:
+                grp_limiter = app.dispatcher.group_limiter
+                _GRP_KEY_SPEC = [
+                    ("max_inflight", grp_limiter.set_max_inflight, int, 1),
+                    ("min_interval", grp_limiter.set_min_interval, float, 0),
+                    ("exhaust_cooldown", grp_limiter.set_exhaust_cooldown, float, 0),
+                ]
+                for grp_name, overrides in grp_block.items():
+                    if not isinstance(overrides, dict):
+                        rejected[f"groups.{grp_name}"] = "must be object"
+                        continue
+                    if not grp_limiter.is_known_group(grp_name):
+                        rejected[f"groups.{grp_name}"] = "unknown group"
+                        continue
+                    for key, setter, vtype, vmin in _GRP_KEY_SPEC:
+                        if key not in overrides:
+                            continue
+                        v = overrides[key]
+                        try:
+                            v = vtype(v)
+                            if v < vmin:
+                                raise ValueError
+                            setter(grp_name, v)
+                            applied[f"groups.{grp_name}.{key}"] = v
+                        except (ValueError, TypeError):
+                            rejected[f"groups.{grp_name}.{key}"] = (
+                                f"must be {vtype.__name__} >= {vmin}"
+                            )
 
             # Endpoint defaults
             ep = body.get("endpoint", {})

--- a/.claude/skills/mcp-async-skill/scripts/queue_config.example.json
+++ b/.claude/skills/mcp-async-skill/scripts/queue_config.example.json
@@ -25,5 +25,16 @@
       "t2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 1800},
       "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
     }
+  },
+  "custom_groups": {
+    "premium-video": {
+      "endpoints": [
+        "https://kamui-code.ai/t2v/fal/veo3*",
+        "https://kamui-code.ai/i2v/fal/veo3*"
+      ],
+      "max_inflight": 1,
+      "min_interval": 30,
+      "exhaust_cooldown": 7200
+    }
   }
 }

--- a/.claude/skills/mcp-async-skill/scripts/queue_config.example.json
+++ b/.claude/skills/mcp-async-skill/scripts/queue_config.example.json
@@ -27,14 +27,32 @@
     }
   },
   "custom_groups": {
-    "premium-video": {
+    "t2v_sd2": {
       "endpoints": [
-        "https://kamui-code.ai/t2v/fal/veo3*",
-        "https://kamui-code.ai/i2v/fal/veo3*"
+        "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0",
+        "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0-fast"
       ],
       "max_inflight": 1,
-      "min_interval": 30,
-      "exhaust_cooldown": 7200
+      "min_interval": 10,
+      "exhaust_cooldown": 3600
+    },
+    "i2v_sd2": {
+      "endpoints": [
+        "https://kamui-code.ai/i2v_sd2/fal/bytedance/seedance-v2.0",
+        "https://kamui-code.ai/i2v_sd2/fal/bytedance/seedance-v2.0-fast"
+      ],
+      "max_inflight": 1,
+      "min_interval": 10,
+      "exhaust_cooldown": 3600
+    },
+    "r2v_sd2": {
+      "endpoints": [
+        "https://kamui-code.ai/r2v_sd2/fal/bytedance/seedance-v2.0-reference",
+        "https://kamui-code.ai/r2v_sd2/fal/bytedance/seedance-v2.0-fast-reference"
+      ],
+      "max_inflight": 1,
+      "min_interval": 10,
+      "exhaust_cooldown": 3600
     }
   }
 }

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_category_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_category_limiter.py
@@ -458,5 +458,105 @@ class TestExtractCategory(unittest.TestCase):
         self.assertIsNone(lim.extract_category("https://example.com"))
 
 
+class TestCooldownExpiredLogOnce(unittest.TestCase):
+    """``can_submit`` logs ``Cooldown expired for X, resuming`` exactly
+    on the transition from "still in cooldown" to "first call after
+    expiry". Without that one-shot guarantee a busy dispatcher would
+    flood the log on every single subsequent dispatch round.
+
+    PR4 review (Codex): the previous condition
+    ``category not in self._exhaust_time and consecutive_429 > 0``
+    stayed true across many later calls because nothing cleared
+    ``consecutive_429`` until ``record_success`` ran. The fix is to
+    snapshot ``had_active_cooldown`` BEFORE the helper call and only
+    log on the active → expired transition.
+    """
+
+    def test_cooldown_expired_log_fires_at_most_once(self):
+        # max_inflight=10 so the cooldown is the only gating factor
+        lim = CategoryLimiter({
+            "categories": ["t2i"],
+            "limits": {"t2i": {"max_inflight": 10, "min_interval": 0.0,
+                                "exhaust_cooldown": 0.05}},
+        })
+        # Pretend a 429 just hit
+        lim.force_cooldown("t2i")
+        lim.record_429("t2i")
+
+        # Wait for the cooldown to expire
+        import time as _time
+        _time.sleep(0.06)
+
+        with self.assertLogs("job_queue.category_limiter", level="INFO") as cm1:
+            # First call after expiry: must log exactly once
+            self.assertTrue(lim.can_submit("t2i"))
+        expired_logs = [m for m in cm1.output if "Cooldown expired" in m]
+        self.assertEqual(len(expired_logs), 1,
+                         f"Expected exactly 1 expired log, got: {cm1.output}")
+
+        # Subsequent calls must NOT re-log even though
+        # _consecutive_429 is still non-zero (record_success has not
+        # run yet because no real submit happened).
+        # assertNoLogs is 3.10+; capture and check manually.
+        import logging as _logging
+        category_logger = _logging.getLogger("job_queue.category_limiter")
+        records: list = []
+
+        class _Capture(_logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = _Capture(level=_logging.INFO)
+        category_logger.addHandler(handler)
+        try:
+            for _ in range(5):
+                lim.can_submit("t2i")
+        finally:
+            category_logger.removeHandler(handler)
+
+        self.assertFalse(
+            any("Cooldown expired" in r.getMessage() for r in records),
+            f"Cooldown expired log must fire only on transition; got "
+            f"{[r.getMessage() for r in records]}",
+        )
+
+
+class TestTouchSubmitUnknownGuard(unittest.TestCase):
+    """``touch_submit`` must respect the same "unknown keys create no
+    state" contract as ``can_submit`` / ``acquire_inflight``.
+
+    PR4 review (Codex): the LimiterStateMixin's bare ``touch_submit``
+    inserts into ``_last_submit`` for any key, so an unknown category
+    fed by mistake (e.g. raw endpoint URL) would slowly grow the
+    dict. CategoryLimiter overrides to guard against that.
+    """
+
+    def test_touch_submit_unknown_creates_no_state(self):
+        lim = CategoryLimiter({
+            "categories": ["t2i"],
+            "limits": {"t2i": {"max_inflight": 1}},
+        })
+        lim.touch_submit("unknown")
+        self.assertNotIn("unknown", lim._last_submit)
+
+    def test_touch_submit_none_is_noop(self):
+        lim = CategoryLimiter({
+            "categories": ["t2i"],
+            "limits": {"t2i": {"max_inflight": 1}},
+        })
+        lim.touch_submit(None)
+        # No exception, no entry created
+        self.assertEqual(lim._last_submit, {})
+
+    def test_touch_submit_known_records_timestamp(self):
+        lim = CategoryLimiter({
+            "categories": ["t2i"],
+            "limits": {"t2i": {"max_inflight": 1}},
+        })
+        lim.touch_submit("t2i")
+        self.assertIn("t2i", lim._last_submit)
+        self.assertGreater(lim._last_submit["t2i"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_custom_group_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_custom_group_limiter.py
@@ -452,5 +452,32 @@ class TestStatusReporting(unittest.TestCase):
         self.assertEqual(cfg["exhaust_cooldown"], 7200)
 
 
+class TestTouchSubmitUnknownGuard(unittest.TestCase):
+    """``touch_submit`` must respect the same "unknown keys create no
+    state" contract as ``can_submit`` / ``acquire_inflight``.
+
+    Mirror of CategoryLimiter's same-named test class. Without the
+    subclass guard the LimiterStateMixin would happily insert an
+    entry into ``_last_submit`` for any key, growing the dict
+    unboundedly if a caller fed it raw endpoint URLs by mistake.
+    """
+
+    def test_touch_submit_unknown_creates_no_state(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        gl.touch_submit("nope")
+        self.assertNotIn("nope", gl._last_submit)
+
+    def test_touch_submit_none_is_noop(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        gl.touch_submit(None)
+        self.assertEqual(gl._last_submit, {})
+
+    def test_touch_submit_known_records_timestamp(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        gl.touch_submit("g")
+        self.assertIn("g", gl._last_submit)
+        self.assertGreater(gl._last_submit["g"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_custom_group_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_custom_group_limiter.py
@@ -1,0 +1,456 @@
+# -*- coding: utf-8 -*-
+"""Tests for ``CustomGroupLimiter`` (PR4 / #60).
+
+Covers:
+
+* Glob-based endpoint matching, including the first-match-wins
+  ordering rule (relies on Python 3.7+ dict insertion order).
+* Per-group isolation of inflight / min_interval / exhaust_cooldown
+  values.
+* Unknown groups return ``False`` from both ``can_submit`` and
+  ``acquire_inflight`` and create no inflight state — same contract
+  CategoryLimiter follows (PHASE1_PLAN_v3 fix #1).
+* The ``_match_cache`` is thread-safe (PHASE1_PLAN_v3 fix #13). Many
+  threads hammering ``extract_group`` produce results consistent with
+  a single-threaded baseline.
+* Empty / malformed groups configuration produces a usable no-op
+  limiter rather than crashing.
+* Public API parity with CategoryLimiter where it matters: getters,
+  setters, pause/resume.
+"""
+import os
+import sys
+import threading
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from job_queue.custom_group_limiter import (  # noqa: E402
+    CustomGroupLimiter,
+    HARDCODED_DEFAULT_EXHAUST_COOLDOWN,
+    HARDCODED_DEFAULT_MAX_INFLIGHT,
+    HARDCODED_DEFAULT_MIN_INTERVAL,
+)
+
+
+def _make_limiter(**groups) -> CustomGroupLimiter:
+    """Build a CustomGroupLimiter from kwargs to keep tests compact."""
+    return CustomGroupLimiter(groups)
+
+
+# ---------------------------------------------------------------------
+# Construction edge cases
+# ---------------------------------------------------------------------
+
+
+class TestEmptyConfiguration(unittest.TestCase):
+    """A bare CustomGroupLimiter is a no-op — useful when no
+    ``custom_groups`` block is present in queue_config."""
+
+    def test_empty_constructor_returns_no_groups(self):
+        gl = CustomGroupLimiter()
+        self.assertEqual(gl.get_groups(), [])
+
+    def test_empty_constructor_extracts_no_group(self):
+        gl = CustomGroupLimiter()
+        self.assertIsNone(gl.extract_group("https://kamui-code.ai/t2v/fal/veo3"))
+
+    def test_empty_constructor_does_not_block_submits(self):
+        gl = CustomGroupLimiter()
+        # extract_group returns None → dispatcher skips the limiter,
+        # so can_submit / acquire_inflight on None must be the same
+        # contract CategoryLimiter has.
+        self.assertTrue(gl.can_submit(None))
+        self.assertFalse(gl.acquire_inflight(None))
+
+
+class TestMalformedConfigurationIsTolerant(unittest.TestCase):
+    """Malformed entries are logged and skipped rather than crashing
+    worker startup."""
+
+    def test_non_dict_spec_is_skipped(self):
+        gl = CustomGroupLimiter({"bad": "not a dict", "good": {
+            "endpoints": ["*"],
+            "max_inflight": 1,
+        }})
+        self.assertEqual(gl.get_groups(), ["good"])
+
+    def test_missing_endpoints_is_skipped(self):
+        gl = CustomGroupLimiter({"bad": {"max_inflight": 1}})
+        self.assertEqual(gl.get_groups(), [])
+
+    def test_empty_endpoints_list_is_skipped(self):
+        gl = CustomGroupLimiter({"bad": {"endpoints": [], "max_inflight": 1}})
+        self.assertEqual(gl.get_groups(), [])
+
+    def test_endpoints_string_instead_of_list_is_skipped(self):
+        # A user might mistakenly write a string. Don't accept it
+        # (str is iterable so we don't want to match character-by-char).
+        gl = CustomGroupLimiter({"bad": {"endpoints": "*", "max_inflight": 1}})
+        self.assertEqual(gl.get_groups(), [])
+
+    def test_custom_groups_wrapper_accepted(self):
+        """Both raw groups dict and a {"custom_groups": ...} wrapper
+        are accepted, since QueueConfig forwards the latter shape."""
+        gl = CustomGroupLimiter({"custom_groups": {
+            "g1": {"endpoints": ["*"], "max_inflight": 1},
+        }})
+        self.assertEqual(gl.get_groups(), ["g1"])
+
+
+# ---------------------------------------------------------------------
+# Glob matching
+# ---------------------------------------------------------------------
+
+
+class TestExtractGroupMatching(unittest.TestCase):
+    def test_simple_glob_matches(self):
+        gl = _make_limiter(**{
+            "premium-video": {
+                "endpoints": ["https://kamui-code.ai/t2v/fal/veo3*"],
+                "max_inflight": 1,
+            },
+        })
+        self.assertEqual(
+            gl.extract_group("https://kamui-code.ai/t2v/fal/veo3-pro"),
+            "premium-video",
+        )
+        self.assertEqual(
+            gl.extract_group("https://kamui-code.ai/t2v/fal/veo3-fast"),
+            "premium-video",
+        )
+
+    def test_no_match_returns_none(self):
+        gl = _make_limiter(**{
+            "premium-video": {
+                "endpoints": ["https://kamui-code.ai/t2v/fal/veo3*"],
+                "max_inflight": 1,
+            },
+        })
+        self.assertIsNone(
+            gl.extract_group("https://kamui-code.ai/t2i/fal/flux-lora"),
+        )
+
+    def test_first_match_wins_in_declaration_order(self):
+        """When two groups would match, the first declared wins."""
+        gl = _make_limiter(**{
+            "specific": {
+                "endpoints": ["https://kamui-code.ai/t2v/fal/veo3-pro"],
+                "max_inflight": 1,
+            },
+            "broad": {
+                "endpoints": ["https://kamui-code.ai/t2v/*"],
+                "max_inflight": 5,
+            },
+        })
+        # The specific pattern is declared first → it wins
+        self.assertEqual(
+            gl.extract_group("https://kamui-code.ai/t2v/fal/veo3-pro"),
+            "specific",
+        )
+
+    def test_case_sensitive(self):
+        """fnmatchcase is case-sensitive — URLs are case-sensitive in
+        practice for these endpoints."""
+        gl = _make_limiter(**{
+            "g": {"endpoints": ["*/Veo*"], "max_inflight": 1},
+        })
+        self.assertIsNone(gl.extract_group("https://x/y/veo"))
+        self.assertEqual(gl.extract_group("https://x/y/Veo3"), "g")
+
+    def test_match_cache_reuses_results(self):
+        gl = _make_limiter(**{
+            "g1": {"endpoints": ["*/veo*"], "max_inflight": 1},
+        })
+        ep = "https://kamui-code.ai/t2v/fal/veo3"
+        first = gl.extract_group(ep)
+        # Second call must return the same result without re-running
+        # the pattern loop. We can't observe that directly, but we can
+        # at least confirm the cache holds a value.
+        with gl._lock:
+            self.assertIn(ep, gl._match_cache)
+        self.assertEqual(gl.extract_group(ep), first)
+
+    def test_match_cache_caches_misses_too(self):
+        gl = _make_limiter(**{
+            "g1": {"endpoints": ["*/veo*"], "max_inflight": 1},
+        })
+        ep_no_match = "https://kamui-code.ai/t2i/fal/flux-lora"
+        self.assertIsNone(gl.extract_group(ep_no_match))
+        with gl._lock:
+            # Cache must record None, not be absent — otherwise we'd
+            # re-walk the pattern list every time for non-matching
+            # endpoints.
+            self.assertIsNone(gl._match_cache[ep_no_match])
+
+
+class TestExtractGroupConcurrentSmoke(unittest.TestCase):
+    """PHASE1_PLAN_v3 fix #13: ``_match_cache`` reads + writes happen
+    under ``self._lock``, so a single-threaded baseline and a racing
+    multi-threaded run must produce the same results.
+
+    This is a smoke test, not a stress test — its job is to catch a
+    regression that drops the lock, not to prove thread safety
+    rigorously."""
+
+    def test_extract_group_concurrent_smoke(self):
+        gl = _make_limiter(**{
+            "g_video": {
+                "endpoints": ["*/veo*", "*/sora*"],
+                "max_inflight": 1,
+            },
+            "g_image": {
+                "endpoints": ["*/seedream*"],
+                "max_inflight": 1,
+            },
+        })
+        endpoints = [
+            "https://kamui-code.ai/t2v/fal/veo3-pro",
+            "https://kamui-code.ai/t2v/fal/sora-1",
+            "https://kamui-code.ai/t2i/fal/seedream-v4",
+            "https://kamui-code.ai/t2i/fal/unknown-model",
+        ] * 200
+
+        # Baseline (single-threaded)
+        baseline = [gl.extract_group(ep) for ep in endpoints]
+
+        # Re-create so the cache starts empty
+        gl2 = _make_limiter(**{
+            "g_video": {
+                "endpoints": ["*/veo*", "*/sora*"],
+                "max_inflight": 1,
+            },
+            "g_image": {
+                "endpoints": ["*/seedream*"],
+                "max_inflight": 1,
+            },
+        })
+
+        results: list = []
+        results_lock = threading.Lock()
+
+        def worker():
+            local: list = []
+            for ep in endpoints:
+                local.append(gl2.extract_group(ep))
+            with results_lock:
+                results.extend(local)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        [t.start() for t in threads]
+        [t.join() for t in threads]
+
+        # Every concurrent result must be one of the baseline outcomes
+        # for its endpoint. We don't assert ordering (threads append
+        # independently), only that no thread saw a corrupted answer.
+        baseline_set = set(baseline)
+        self.assertTrue(set(results).issubset(baseline_set))
+
+
+# ---------------------------------------------------------------------
+# Submit gating
+# ---------------------------------------------------------------------
+
+
+class TestPerGroupIsolation(unittest.TestCase):
+    def test_inflight_per_group_does_not_leak(self):
+        gl = _make_limiter(**{
+            "g_a": {"endpoints": ["*"], "max_inflight": 2},
+            "g_b": {"endpoints": ["*"], "max_inflight": 3},
+        })
+        # Saturate g_a
+        self.assertTrue(gl.acquire_inflight("g_a"))
+        self.assertTrue(gl.acquire_inflight("g_a"))
+        self.assertFalse(gl.acquire_inflight("g_a"))  # full
+        # g_b unaffected
+        self.assertTrue(gl.acquire_inflight("g_b"))
+        self.assertTrue(gl.acquire_inflight("g_b"))
+        self.assertTrue(gl.acquire_inflight("g_b"))
+        self.assertFalse(gl.acquire_inflight("g_b"))
+
+
+class TestUnknownGroupRejection(unittest.TestCase):
+    """PHASE1_PLAN_v3 fix #1: parity with CategoryLimiter — unknown
+    keys return False from both can_submit and acquire_inflight, and
+    no inflight state is created."""
+
+    def test_unknown_group_returns_false_from_can_submit(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        self.assertFalse(gl.can_submit("nope"))
+
+    def test_unknown_group_returns_false_from_acquire_inflight(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        self.assertFalse(gl.acquire_inflight("nope"))
+        # State must not be created
+        with gl._lock:
+            self.assertNotIn("nope", gl._inflight)
+
+    def test_unknown_group_release_inflight_is_noop(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        # No exception, no state change
+        gl.release_inflight("nope", success=True)
+
+
+class TestNoneKeyHandling(unittest.TestCase):
+    """``key=None`` (= category-less and unmatched-by-group) must let
+    the dispatcher pass through. CategoryLimiter behaves the same."""
+
+    def test_none_key_can_submit_returns_true(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        self.assertTrue(gl.can_submit(None))
+
+    def test_none_key_acquire_inflight_returns_false(self):
+        # No accounting state for None
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        self.assertFalse(gl.acquire_inflight(None))
+
+
+# ---------------------------------------------------------------------
+# Hardcoded fallback
+# ---------------------------------------------------------------------
+
+
+class TestHardcodedFallback(unittest.TestCase):
+    """When a group spec omits a key, the limiter falls back to module
+    defaults — same safety net as CategoryLimiter."""
+
+    def test_missing_max_inflight_uses_default(self):
+        gl = _make_limiter(**{
+            "g": {"endpoints": ["*"]},  # max_inflight intentionally missing
+        })
+        self.assertEqual(gl.get_max_inflight("g"), HARDCODED_DEFAULT_MAX_INFLIGHT)
+
+    def test_missing_min_interval_uses_default(self):
+        gl = _make_limiter(**{
+            "g": {"endpoints": ["*"], "max_inflight": 5},
+        })
+        self.assertEqual(gl.get_min_interval("g"), HARDCODED_DEFAULT_MIN_INTERVAL)
+
+    def test_missing_exhaust_cooldown_uses_default(self):
+        gl = _make_limiter(**{
+            "g": {"endpoints": ["*"], "max_inflight": 5},
+        })
+        self.assertEqual(
+            gl.get_exhaust_cooldown("g"), HARDCODED_DEFAULT_EXHAUST_COOLDOWN,
+        )
+
+    def test_unknown_group_getters_return_hardcoded_defaults(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 9}})
+        self.assertEqual(
+            gl.get_max_inflight("nope"), HARDCODED_DEFAULT_MAX_INFLIGHT,
+        )
+        self.assertEqual(
+            gl.get_min_interval("nope"), HARDCODED_DEFAULT_MIN_INTERVAL,
+        )
+        self.assertEqual(
+            gl.get_exhaust_cooldown("nope"), HARDCODED_DEFAULT_EXHAUST_COOLDOWN,
+        )
+
+
+# ---------------------------------------------------------------------
+# Pause / resume / cooldown
+# ---------------------------------------------------------------------
+
+
+class TestPauseAndCooldown(unittest.TestCase):
+    def test_pause_blocks_submit(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        gl.pause_group("g")
+        self.assertFalse(gl.can_submit("g"))
+        self.assertTrue(gl.is_paused("g"))
+
+    def test_resume_unblocks_submit(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        gl.pause_group("g")
+        gl.resume_group("g")
+        self.assertTrue(gl.can_submit("g"))
+        self.assertFalse(gl.is_paused("g"))
+
+    def test_pause_unknown_group_is_noop(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        gl.pause_group("nope")
+        self.assertFalse(gl.is_paused("nope"))
+
+    def test_force_cooldown_blocks_submit(self):
+        gl = _make_limiter(**{
+            "g": {"endpoints": ["*"], "max_inflight": 1, "exhaust_cooldown": 1800},
+        })
+        gl.force_cooldown("g")
+        # Still in cooldown — can_submit returns False
+        self.assertFalse(gl.can_submit("g"))
+        # And get_all_status reports remaining time
+        status = gl.get_all_status()
+        self.assertGreater(status["g"]["cooldown_remaining_s"], 1700)
+
+    def test_resume_clears_cooldown(self):
+        gl = _make_limiter(**{
+            "g": {"endpoints": ["*"], "max_inflight": 1, "exhaust_cooldown": 1800},
+        })
+        gl.force_cooldown("g")
+        gl.resume_group("g")
+        self.assertTrue(gl.can_submit("g"))
+
+
+# ---------------------------------------------------------------------
+# Setters
+# ---------------------------------------------------------------------
+
+
+class TestRuntimeSetters(unittest.TestCase):
+    def test_set_max_inflight_updates_only_target(self):
+        gl = _make_limiter(**{
+            "g_a": {"endpoints": ["*"], "max_inflight": 1},
+            "g_b": {"endpoints": ["*"], "max_inflight": 1},
+        })
+        gl.set_max_inflight("g_a", 7)
+        self.assertEqual(gl.get_max_inflight("g_a"), 7)
+        self.assertEqual(gl.get_max_inflight("g_b"), 1)
+
+    def test_set_unknown_group_warns_and_is_ignored(self):
+        gl = _make_limiter(**{"g": {"endpoints": ["*"], "max_inflight": 1}})
+        with self.assertLogs("job_queue.custom_group_limiter", level="WARNING") as cm:
+            gl.set_max_inflight("nope", 99)
+        self.assertTrue(any("unknown group" in m for m in cm.output))
+
+
+# ---------------------------------------------------------------------
+# Status reporting
+# ---------------------------------------------------------------------
+
+
+class TestStatusReporting(unittest.TestCase):
+    def test_get_all_status_includes_endpoints_and_limits(self):
+        gl = _make_limiter(**{
+            "g": {
+                "endpoints": ["*/veo*"],
+                "max_inflight": 1,
+                "min_interval": 30,
+                "exhaust_cooldown": 7200,
+            },
+        })
+        status = gl.get_all_status()["g"]
+        self.assertEqual(status["endpoints"], ["*/veo*"])
+        self.assertEqual(status["max_inflight"], 1)
+        self.assertEqual(status["min_interval"], 30)
+        self.assertEqual(status["exhaust_cooldown"], 7200)
+        self.assertEqual(status["paused"], False)
+        self.assertEqual(status["inflight"], 0)
+
+    def test_get_config_round_trips_constructor(self):
+        gl = _make_limiter(**{
+            "g": {
+                "endpoints": ["*/veo*"],
+                "max_inflight": 1,
+                "min_interval": 30,
+                "exhaust_cooldown": 7200,
+            },
+        })
+        cfg = gl.get_config()["custom_groups"]["g"]
+        self.assertEqual(cfg["endpoints"], ["*/veo*"])
+        self.assertEqual(cfg["max_inflight"], 1)
+        self.assertEqual(cfg["min_interval"], 30)
+        self.assertEqual(cfg["exhaust_cooldown"], 7200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_dispatcher_groups.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_dispatcher_groups.py
@@ -1,0 +1,312 @@
+# -*- coding: utf-8 -*-
+"""Tests for dispatcher integration of CustomGroupLimiter (PR4 / #60).
+
+Covers:
+
+* ``_resolve_limiter()`` returns the correct limiter for an endpoint:
+  custom group on match, category on category prefix match, ``(None,
+  None)`` on truly unknown endpoint.
+* When an endpoint matches a custom group, accounting goes to the
+  group limiter and the category limiter is NOT charged. (This is the
+  whole point of custom_groups — special-case throttling without
+  inflating the parent category's quota.)
+* When an endpoint matches no group but has a recognised category
+  prefix, accounting goes to the category limiter (unchanged
+  pre-PR4 behaviour).
+* When an endpoint matches no group AND no category, the dispatcher
+  schedules it without any per-key accounting (parity with the
+  pre-PR4 ``test_dispatcher_rate_limit::TestUnknownCategoryEndpointDispatch``).
+* 429 / non-429 error handling routes through the resolved limiter.
+"""
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from job_queue.db import JobStore
+from job_queue.dispatcher import Dispatcher, QueueConfig
+
+
+class _FakeResponse:
+    def __init__(self, status_code, headers=None):
+        self.status_code = status_code
+        self.headers = headers or {}
+
+
+class _FakeHTTPError(Exception):
+    def __init__(self, response=None):
+        super().__init__(f"HTTP {response.status_code}" if response else "HTTP Error")
+        self.response = response
+
+
+class _ResolveLimiterBase(unittest.TestCase):
+    """Builds a Dispatcher with the configured custom_groups and a
+    no-op executor. Tests can call ``self.dispatcher._resolve_limiter``
+    directly without going through the dispatch loop."""
+
+    custom_groups: dict = {}
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.store = JobStore(self.tmp.name)
+        self.config = QueueConfig.from_dict({
+            "custom_groups": self.custom_groups,
+            # Provide a known-category list so extract_category works
+            "category_rate_limits": {
+                "categories": ["t2i", "i2i", "t2v", "i2v"],
+                "limits": {
+                    "t2i": {"max_inflight": 3, "min_interval": 0.0,
+                             "exhaust_cooldown": 60},
+                    "i2i": {"max_inflight": 2, "min_interval": 0.0,
+                             "exhaust_cooldown": 60},
+                    "t2v": {"max_inflight": 1, "min_interval": 0.0,
+                             "exhaust_cooldown": 60},
+                    "i2v": {"max_inflight": 1, "min_interval": 0.0,
+                             "exhaust_cooldown": 60},
+                },
+            },
+        })
+        self.executed: list[str] = []
+
+        def recording_executor(job):
+            self.executed.append(job["id"])
+
+        self.dispatcher = Dispatcher(
+            store=self.store,
+            config=self.config,
+            job_executor=recording_executor,
+            loop_interval=0.01,
+        )
+
+    def tearDown(self):
+        try:
+            self.dispatcher.stop()
+        except Exception:
+            pass
+        self.store.close()
+        try:
+            os.unlink(self.tmp.name)
+        except FileNotFoundError:
+            pass
+
+
+# ---------------------------------------------------------------------
+# _resolve_limiter() shape
+# ---------------------------------------------------------------------
+
+
+class TestResolveLimiterMatching(_ResolveLimiterBase):
+    custom_groups = {
+        "premium-video": {
+            "endpoints": ["https://kamui-code.ai/t2v/fal/veo3*"],
+            "max_inflight": 1,
+        },
+    }
+
+    def test_group_match_returns_group_limiter(self):
+        limiter, key = self.dispatcher._resolve_limiter(
+            "https://kamui-code.ai/t2v/fal/veo3-pro",
+        )
+        self.assertIs(limiter, self.dispatcher.group_limiter)
+        self.assertEqual(key, "premium-video")
+
+    def test_category_match_returns_category_limiter(self):
+        limiter, key = self.dispatcher._resolve_limiter(
+            "https://kamui-code.ai/t2i/fal/flux-lora",
+        )
+        self.assertIs(limiter, self.dispatcher.category_limiter)
+        self.assertEqual(key, "t2i")
+
+    def test_unknown_endpoint_returns_none_none(self):
+        limiter, key = self.dispatcher._resolve_limiter(
+            "https://example.com/some/random/path",
+        )
+        self.assertIsNone(limiter)
+        self.assertIsNone(key)
+
+    def test_group_takes_precedence_over_category(self):
+        """An endpoint that BOTH matches a group AND has a recognised
+        category prefix must go to the group, not the category."""
+        ep = "https://kamui-code.ai/t2v/fal/veo3-pro"
+        # Sanity: the endpoint also extracts a category
+        self.assertEqual(
+            self.dispatcher.category_limiter.extract_category(ep), "t2v",
+        )
+        limiter, key = self.dispatcher._resolve_limiter(ep)
+        self.assertIs(limiter, self.dispatcher.group_limiter)
+        self.assertEqual(key, "premium-video")
+
+
+# ---------------------------------------------------------------------
+# Dispatch goes through the resolved limiter
+# ---------------------------------------------------------------------
+
+
+class TestGroupAccountingIsolation(_ResolveLimiterBase):
+    """When an endpoint matches a group, the category limiter must not
+    be charged for it. This is the headline reason custom_groups
+    exists."""
+
+    custom_groups = {
+        "premium-video": {
+            "endpoints": ["https://kamui-code.ai/t2v/fal/veo3*"],
+            "max_inflight": 1,
+            "min_interval": 0.0,
+            "exhaust_cooldown": 60,
+        },
+    }
+
+    def test_group_endpoint_creates_no_category_inflight(self):
+        ep = "https://kamui-code.ai/t2v/fal/veo3-pro"
+
+        def failing_executor(job):
+            raise _FakeHTTPError(response=_FakeResponse(429))
+
+        self.dispatcher.job_executor = failing_executor
+
+        job_id = self.store.insert_job(
+            endpoint=ep, submit_tool="submit", args="{}",
+        )
+        job = self.store.get_job(job_id)
+        self.store.update_status(job_id, "running")
+        self.dispatcher._run_job(job)
+
+        # Group counter saw the 429
+        gstatus = self.dispatcher.group_limiter.get_all_status()["premium-video"]
+        self.assertGreater(gstatus["consecutive_429"], 0)
+
+        # Category counter must NOT have been charged for the same hit
+        cstatus = self.dispatcher.category_limiter.get_all_status()["t2v"]
+        self.assertEqual(cstatus["consecutive_429"], 0)
+        self.assertEqual(cstatus["inflight"], 0)
+
+
+class TestCategoryEndpointStillUsesCategoryLimiter(_ResolveLimiterBase):
+    """An endpoint with a category prefix and no group match must
+    still go through the category limiter (no regression vs PR1)."""
+
+    custom_groups = {
+        "premium-video": {
+            "endpoints": ["https://kamui-code.ai/t2v/fal/veo3*"],
+            "max_inflight": 1,
+        },
+    }
+
+    def test_t2i_endpoint_charges_category_only(self):
+        ep = "https://kamui-code.ai/t2i/fal/flux-lora"
+
+        def failing_executor(job):
+            raise _FakeHTTPError(response=_FakeResponse(429))
+
+        self.dispatcher.job_executor = failing_executor
+
+        job_id = self.store.insert_job(
+            endpoint=ep, submit_tool="submit", args="{}",
+        )
+        job = self.store.get_job(job_id)
+        self.store.update_status(job_id, "running")
+        self.dispatcher._run_job(job)
+
+        cstatus = self.dispatcher.category_limiter.get_all_status()["t2i"]
+        self.assertGreater(cstatus["consecutive_429"], 0)
+
+        gstatus = self.dispatcher.group_limiter.get_all_status()
+        # premium-video group must not have been charged
+        self.assertEqual(gstatus["premium-video"]["consecutive_429"], 0)
+
+
+class TestUnknownEndpointStillDispatches(_ResolveLimiterBase):
+    """Pre-PR4 behaviour preserved: an endpoint matching neither a
+    group nor a recognised category dispatches without any per-key
+    accounting being created. This is the PR1
+    ``TestUnknownCategoryEndpointDispatch`` contract."""
+
+    custom_groups = {
+        "premium-video": {
+            "endpoints": ["https://kamui-code.ai/t2v/fal/veo3*"],
+            "max_inflight": 1,
+        },
+    }
+
+    def test_unknown_endpoint_dispatches(self):
+        ep = "https://example.com/some/random/path"
+        # Sanity precondition
+        limiter, key = self.dispatcher._resolve_limiter(ep)
+        self.assertIsNone(limiter)
+        self.assertIsNone(key)
+
+        job_id = self.store.insert_job(
+            endpoint=ep, submit_tool="submit", args="{}",
+        )
+        dispatched = self.dispatcher.dispatch_once()
+        self.assertEqual(dispatched, 1)
+
+        # Wait for executor
+        for _ in range(50):
+            if self.executed:
+                break
+            time.sleep(0.02)
+        self.assertEqual(self.executed, [job_id])
+
+        # No per-key accounting created in either limiter
+        with self.dispatcher.category_limiter._lock:
+            self.assertEqual(self.dispatcher.category_limiter._inflight, {})
+        with self.dispatcher.group_limiter._lock:
+            self.assertEqual(self.dispatcher.group_limiter._inflight, {})
+
+
+class TestNoGroupConfigurationFallsBackToCategory(unittest.TestCase):
+    """When no ``custom_groups`` block is present at all, every
+    endpoint with a category prefix still routes to the category
+    limiter — same as pre-PR4."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.store = JobStore(self.tmp.name)
+        self.config = QueueConfig.from_dict({
+            "category_rate_limits": {
+                "categories": ["t2i", "i2i", "t2v", "i2v"],
+                "limits": {
+                    "t2v": {"max_inflight": 1, "min_interval": 0.0,
+                             "exhaust_cooldown": 60},
+                },
+            },
+            # No custom_groups key at all
+        })
+        self.dispatcher = Dispatcher(
+            store=self.store,
+            config=self.config,
+            job_executor=lambda job: None,
+            loop_interval=0.01,
+        )
+
+    def tearDown(self):
+        try:
+            self.dispatcher.stop()
+        except Exception:
+            pass
+        self.store.close()
+        try:
+            os.unlink(self.tmp.name)
+        except FileNotFoundError:
+            pass
+
+    def test_t2v_endpoint_routes_to_category(self):
+        ep = "https://kamui-code.ai/t2v/fal/veo3-pro"
+        limiter, key = self.dispatcher._resolve_limiter(ep)
+        self.assertIs(limiter, self.dispatcher.category_limiter)
+        self.assertEqual(key, "t2v")
+
+    def test_group_limiter_is_present_but_empty(self):
+        # PR4 always creates the group_limiter for shape consistency
+        self.assertIsNotNone(self.dispatcher.group_limiter)
+        self.assertEqual(self.dispatcher.group_limiter.get_groups(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_generate_skill_queue.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_generate_skill_queue.py
@@ -47,6 +47,51 @@ class TestGenerateQueueConfig(unittest.TestCase):
         self.assertIsInstance(cfg["port"], int)
         self.assertGreater(cfg["idle_timeout_seconds"], 0)
 
+    def test_seedance_default_groups_present(self):
+        """PR4 (#60): the generated queue_config ships with the
+        Bytedance Seedance v2.0 video custom_groups out of the box.
+
+        These groups are pinned because the upstream URL prefixes
+        (`t2v_sd2`, `i2v_sd2`, `r2v_sd2`) are not in the standard
+        category list — without these groups, the dispatcher would
+        treat these high-cost endpoints as "unknown" and skip
+        rate-limit accounting entirely. Removing or renaming them
+        in `generate_queue_config()` is a behaviour change that
+        should fail this test."""
+        cfg = generate_skill.generate_queue_config("http://x:8000")
+        self.assertIn("custom_groups", cfg)
+        groups = cfg["custom_groups"]
+        self.assertEqual(set(groups.keys()), {"t2v_sd2", "i2v_sd2", "r2v_sd2"})
+
+    def test_seedance_default_groups_have_expected_endpoints(self):
+        cfg = generate_skill.generate_queue_config("http://x:8000")
+        groups = cfg["custom_groups"]
+        # Each variant pair (base + fast / reference + fast-reference)
+        self.assertEqual(groups["t2v_sd2"]["endpoints"], [
+            "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0",
+            "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0-fast",
+        ])
+        self.assertEqual(groups["i2v_sd2"]["endpoints"], [
+            "https://kamui-code.ai/i2v_sd2/fal/bytedance/seedance-v2.0",
+            "https://kamui-code.ai/i2v_sd2/fal/bytedance/seedance-v2.0-fast",
+        ])
+        self.assertEqual(groups["r2v_sd2"]["endpoints"], [
+            "https://kamui-code.ai/r2v_sd2/fal/bytedance/seedance-v2.0-reference",
+            "https://kamui-code.ai/r2v_sd2/fal/bytedance/seedance-v2.0-fast-reference",
+        ])
+
+    def test_seedance_default_groups_use_conservative_limits(self):
+        """All three groups use the same conservative defaults
+        (max_inflight=1, min_interval=10s, exhaust_cooldown=3600s).
+        Users can tune them up in queue_config.json once they have
+        observed real-world headroom."""
+        cfg = generate_skill.generate_queue_config("http://x:8000")
+        for name in ("t2v_sd2", "i2v_sd2", "r2v_sd2"):
+            g = cfg["custom_groups"][name]
+            self.assertEqual(g["max_inflight"], 1, msg=name)
+            self.assertEqual(g["min_interval"], 10, msg=name)
+            self.assertEqual(g["exhaust_cooldown"], 3600, msg=name)
+
 
 # ── 6-2. File Copy Tests ────────────────────────────────────────────────
 

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_worker_groups.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_worker_groups.py
@@ -1,0 +1,320 @@
+# -*- coding: utf-8 -*-
+"""Tests for the worker HTTP API surface introduced for custom groups
+(PR4 / #60).
+
+Covers:
+
+* ``GET /api/groups`` returns runtime status of every configured
+  custom group.
+* ``GET /api/config`` includes a ``custom_groups`` block with the
+  per-group config.
+* ``GET /api/stats`` includes a ``custom_groups`` section alongside
+  ``category_limits``.
+* ``POST /api/groups/{name}/{pause|resume}`` toggles the group's
+  paused state, returns the new status, and rejects unknown group
+  names with HTTP 404.
+* ``PATCH /api/config`` accepts ``{"groups": {"name": {"max_inflight":
+  N}}}`` for per-group runtime tuning, validates types, and rejects
+  unknown groups.
+* When a custom group is paused, ``POST /api/jobs`` returns a warning
+  pointing at the group (not the category).
+"""
+import os
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import requests
+
+from job_queue import worker
+
+
+def get_free_port():
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _GroupsWorkerBase(unittest.TestCase):
+    """Boots a worker with a known custom_groups + categories config."""
+
+    def setUp(self):
+        self.port = get_free_port()
+        self.base_url = f"http://127.0.0.1:{self.port}"
+
+        self.worker_app = worker.WorkerApp(
+            host="127.0.0.1",
+            port=self.port,
+            db_path=":memory:",
+            config_dict={
+                "default_rate_limit": {
+                    "max_concurrent_jobs": 5,
+                    "min_interval_seconds": 0.0,
+                },
+                "category_rate_limits": {
+                    "categories": ["t2i", "i2i", "t2v", "i2v"],
+                    "limits": {
+                        "t2v": {"max_inflight": 1, "min_interval": 0.0,
+                                 "exhaust_cooldown": 60},
+                    },
+                },
+                "custom_groups": {
+                    "premium-video": {
+                        "endpoints": ["https://kamui-code.ai/t2v/fal/veo3*"],
+                        "max_inflight": 1,
+                        "min_interval": 30,
+                        "exhaust_cooldown": 7200,
+                    },
+                    "expensive-edit": {
+                        "endpoints": ["https://kamui-code.ai/i2i/fal/gpt-image*"],
+                        "max_inflight": 2,
+                        "min_interval": 5,
+                        "exhaust_cooldown": 1800,
+                    },
+                },
+            },
+            job_executor=lambda job: None,
+            idle_timeout=0,
+        )
+        self.worker_app.start()
+
+        for _ in range(50):
+            try:
+                requests.get(f"{self.base_url}/api/health", timeout=0.5)
+                break
+            except requests.ConnectionError:
+                time.sleep(0.05)
+
+    def tearDown(self):
+        self.worker_app.stop()
+
+
+# ---------------------------------------------------------------------
+# GET endpoints
+# ---------------------------------------------------------------------
+
+
+class TestGetGroupsEndpoint(_GroupsWorkerBase):
+    def test_returns_all_configured_groups(self):
+        resp = requests.get(f"{self.base_url}/api/groups")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertIn("groups", body)
+        self.assertEqual(set(body["groups"].keys()),
+                         {"premium-video", "expensive-edit"})
+
+    def test_each_group_has_status_fields(self):
+        body = requests.get(f"{self.base_url}/api/groups").json()
+        g = body["groups"]["premium-video"]
+        self.assertEqual(g["max_inflight"], 1)
+        self.assertEqual(g["exhaust_cooldown"], 7200)
+        self.assertEqual(g["paused"], False)
+        self.assertEqual(g["inflight"], 0)
+        self.assertIn("endpoints", g)
+        self.assertEqual(g["endpoints"],
+                         ["https://kamui-code.ai/t2v/fal/veo3*"])
+
+    def test_includes_server_time(self):
+        body = requests.get(f"{self.base_url}/api/groups").json()
+        self.assertIn("server_time_utc", body)
+        self.assertTrue(body["server_time_utc"].endswith("Z"))
+
+
+class TestGetConfigIncludesCustomGroups(_GroupsWorkerBase):
+    def test_config_has_custom_groups_block(self):
+        body = requests.get(f"{self.base_url}/api/config").json()
+        self.assertIn("custom_groups", body)
+        self.assertIn("premium-video", body["custom_groups"])
+        cfg = body["custom_groups"]["premium-video"]
+        self.assertEqual(cfg["max_inflight"], 1)
+        self.assertEqual(cfg["min_interval"], 30)
+        self.assertEqual(cfg["exhaust_cooldown"], 7200)
+
+    def test_config_still_has_category_block(self):
+        """custom_groups addition must not break the existing
+        category section consumed by the dashboard."""
+        body = requests.get(f"{self.base_url}/api/config").json()
+        self.assertIn("category", body)
+        self.assertIn("limits", body["category"])
+
+
+class TestGetStatsIncludesCustomGroups(_GroupsWorkerBase):
+    def test_stats_has_custom_groups_section(self):
+        body = requests.get(f"{self.base_url}/api/stats").json()
+        self.assertIn("custom_groups", body)
+        self.assertIn("premium-video", body["custom_groups"])
+
+    def test_stats_still_has_category_limits(self):
+        body = requests.get(f"{self.base_url}/api/stats").json()
+        self.assertIn("category_limits", body)
+        self.assertIn("t2v", body["category_limits"])
+
+
+# ---------------------------------------------------------------------
+# POST /api/groups/{name}/{action}
+# ---------------------------------------------------------------------
+
+
+class TestGroupPauseResume(_GroupsWorkerBase):
+    def test_pause_marks_group_paused(self):
+        resp = requests.post(
+            f"{self.base_url}/api/groups/premium-video/pause",
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["group"], "premium-video")
+        self.assertTrue(body["paused"])
+        self.assertEqual(body["status"]["paused"], True)
+
+        # Confirm via GET
+        groups = requests.get(f"{self.base_url}/api/groups").json()["groups"]
+        self.assertTrue(groups["premium-video"]["paused"])
+
+    def test_resume_clears_paused(self):
+        requests.post(f"{self.base_url}/api/groups/premium-video/pause")
+        resp = requests.post(
+            f"{self.base_url}/api/groups/premium-video/resume",
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertFalse(body["paused"])
+
+        groups = requests.get(f"{self.base_url}/api/groups").json()["groups"]
+        self.assertFalse(groups["premium-video"]["paused"])
+
+    def test_unknown_group_returns_404(self):
+        resp = requests.post(
+            f"{self.base_url}/api/groups/nonexistent/pause",
+        )
+        self.assertEqual(resp.status_code, 404)
+        body = resp.json()
+        self.assertIn("error", body)
+        self.assertIn("Unknown group", body["error"])
+        # Lists available groups so the user can fix their request
+        self.assertIn("available_groups", body)
+        self.assertIn("premium-video", body["available_groups"])
+
+    def test_invalid_action_returns_400(self):
+        resp = requests.post(
+            f"{self.base_url}/api/groups/premium-video/invalid-action",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+
+# ---------------------------------------------------------------------
+# PATCH /api/config — groups block
+# ---------------------------------------------------------------------
+
+
+class TestPatchGroupsConfig(_GroupsWorkerBase):
+    def test_patch_single_group_max_inflight(self):
+        body = {"groups": {"premium-video": {"max_inflight": 3}}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("groups.premium-video.max_inflight", data["applied"])
+        self.assertEqual(data["applied"]["groups.premium-video.max_inflight"], 3)
+        self.assertEqual(data["rejected"], {})
+
+        # Confirm via GET
+        groups = requests.get(f"{self.base_url}/api/groups").json()["groups"]
+        self.assertEqual(groups["premium-video"]["max_inflight"], 3)
+        # Other group untouched
+        self.assertEqual(groups["expensive-edit"]["max_inflight"], 2)
+
+    def test_patch_multiple_groups(self):
+        body = {"groups": {
+            "premium-video": {"max_inflight": 5},
+            "expensive-edit": {"exhaust_cooldown": 9000},
+        }}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertEqual(resp.status_code, 200)
+        groups = requests.get(f"{self.base_url}/api/groups").json()["groups"]
+        self.assertEqual(groups["premium-video"]["max_inflight"], 5)
+        self.assertEqual(groups["expensive-edit"]["exhaust_cooldown"], 9000)
+
+    def test_unknown_group_rejected(self):
+        body = {"groups": {"nope": {"max_inflight": 1}}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        rejected = resp.json()["rejected"]
+        self.assertIn("groups.nope", rejected)
+        self.assertIn("unknown group", rejected["groups.nope"])
+
+    def test_groups_must_be_dict(self):
+        body = {"groups": [1, 2, 3]}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        rejected = resp.json()["rejected"]
+        self.assertIn("groups", rejected)
+        self.assertIn("must be object", rejected["groups"])
+
+    def test_per_group_value_must_be_dict(self):
+        body = {"groups": {"premium-video": "not-a-dict"}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        rejected = resp.json()["rejected"]
+        self.assertIn("groups.premium-video", rejected)
+
+    def test_max_inflight_must_be_int_ge_1(self):
+        body = {"groups": {"premium-video": {"max_inflight": 0}}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        self.assertIn("groups.premium-video.max_inflight",
+                      resp.json()["rejected"])
+
+    def test_partial_failure_applies_valid_only(self):
+        body = {"groups": {"premium-video": {
+            "max_inflight": 4,        # valid
+            "exhaust_cooldown": -1,   # invalid
+        }}}
+        resp = requests.patch(f"{self.base_url}/api/config", json=body)
+        data = resp.json()
+        self.assertEqual(data["applied"]["groups.premium-video.max_inflight"], 4)
+        self.assertIn("groups.premium-video.exhaust_cooldown", data["rejected"])
+
+        groups = requests.get(f"{self.base_url}/api/groups").json()["groups"]
+        self.assertEqual(groups["premium-video"]["max_inflight"], 4)
+        # The invalid one didn't change anything
+        self.assertEqual(groups["premium-video"]["exhaust_cooldown"], 7200)
+
+
+# ---------------------------------------------------------------------
+# POST /api/jobs — group-aware pause warning
+# ---------------------------------------------------------------------
+
+
+class TestSubmitWarningWhenGroupPaused(_GroupsWorkerBase):
+    def test_warning_mentions_group_when_group_is_paused(self):
+        # Pause the group
+        requests.post(f"{self.base_url}/api/groups/premium-video/pause")
+
+        # Submit a job to a group-matching endpoint
+        resp = requests.post(f"{self.base_url}/api/jobs", json={
+            "endpoint": "https://kamui-code.ai/t2v/fal/veo3-pro",
+            "submit_tool": "submit",
+            "args": {"prompt": "test"},
+        })
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertIn("warning", body)
+        self.assertIn("Group premium-video", body["warning"])
+
+    def test_warning_mentions_category_when_category_is_paused(self):
+        # Confirm category-only path still warns about the category
+        # (not a group). t2v/fal/some-other-model doesn't match the
+        # premium-video pattern, so it routes to the t2v category.
+        cl = self.worker_app.dispatcher.category_limiter
+        cl.pause_category("t2v")
+
+        resp = requests.post(f"{self.base_url}/api/jobs", json={
+            "endpoint": "https://kamui-code.ai/t2v/fal/some-other-model",
+            "submit_tool": "submit",
+            "args": {"prompt": "test"},
+        })
+        body = resp.json()
+        self.assertIn("warning", body)
+        self.assertIn("Category t2v", body["warning"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@
   - migration 失敗時は connection を close して例外を re-raise (Windows 環境でファイルハンドル即解放)
   - 詳細: [docs/db-migration.md](docs/db-migration.md)
 - 新規テスト: `test_db_migrations.py` (12 tests), 新規 DB / pre-PR3 DB upgrade / missing column rejection / extra columns warn / type drift acceptance / registry shape / driver behaviour をカバー
+- **Custom Groups (endpoint-pattern rate limiting)** (#60): endpoint URL の glob パターンで独自グループを定義し、カテゴリと独立に inflight / min_interval / 429 cooldown を制御
+  - 新スキーマ `custom_groups.{name}` (`endpoints` / `max_inflight` / `min_interval` / `exhaust_cooldown`)
+  - **マッチした endpoint はカテゴリ計上から完全除外** — 群を厳しく絞ってもカテゴリ全体には影響しない
+  - First-match-wins 順序 (Python 3.7+ の dict 挿入順保証)、glob は fnmatch ベース case-sensitive
+  - 新規モジュール `job_queue/custom_group_limiter.py` + 共通 `job_queue/limiter_state.py` (`LimiterStateMixin`)。CategoryLimiter も同 mixin に再構成し、状態管理を 1 箇所に集約 (バグ修正・拡張が一度で済む)
+  - 新規 API: `GET /api/groups`, `POST /api/groups/{name}/{pause|resume}` (404 with `available_groups`), `PATCH /api/config` の `groups` block 受理 (per-category と同じ validation pattern)
+  - `GET /api/config` / `GET /api/stats` レスポンスに `custom_groups` セクション追加
+  - `POST /api/jobs` の pause warning が resolved limiter (group/category) を反映
+  - dispatcher は新ヘルパー `_resolve_limiter(endpoint) -> (limiter, key)` 1 箇所経由で limiter にアクセス。group → category → `(None, None)` の優先順位、unknown endpoint は per-key accounting なしで dispatch (PR1 `TestUnknownCategoryEndpointDispatch` 契約維持)
+  - **Bytedance Seedance v2.0 動画モデル群 (`t2v_sd2` / `i2v_sd2` / `r2v_sd2`) を初期同梱** (`generate_skill.py` テンプレート + `queue_config.example.json`)。URL prefix が標準カテゴリ list 外のため、未設定だと rate-limit accounting がスキップされる問題への安全策
+  - 詳細: [docs/custom-groups.md](docs/custom-groups.md)
+- 新規テスト: `test_custom_group_limiter.py` (38 tests), `test_dispatcher_groups.py` (12 tests), `test_worker_groups.py` (16 tests), `test_generate_skill_queue.py` の Seedance pin (3 tests) — 構築 / glob / concurrent smoke / unknown handling / dispatcher routing isolation / HTTP API / template defaults をカバー
 
 ### Changed (BREAKING)
 - **`set_max_inflight(cat, value)` の `cat` 引数必須化**: lazy-v2.10.x の単一引数 `set_max_inflight(value)` (全カテゴリ一括変更) は削除。`set_min_interval` / `set_exhaust_cooldown` も同様。worker の `PATCH /api/config` ハンドラが「全カテゴリ一括」の API レイヤを emulate する。
@@ -53,6 +65,8 @@
 - **lazy-v2.10.x の queue_config.json (旧 flat schema) は引き続き動作**します (起動時に `[CategoryLimiter] (instance ...) DEPRECATED: ...` 警告ログが 1 回出力)
 - **lazy-v2.10.x dashboard は引き続き動作**します (`GET /api/config` の旧互換ミラーキーで UI 値が空にならない)。ただし旧 dashboard から値編集すると **新 worker は全カテゴリに一括適用** します。per-category 編集には `lazy-v2.12.0` 以降の dashboard が必要。
 - **lazy-v2.10.x worker と lazy-v2.11.0 client の組み合わせ**: 新クライアントは旧 worker から `X-Worker-Version` が返らないことを検知し、stderr に「pre-v2.11.0 worker の可能性、shutdown して再起動を」と 1 回警告します。処理は止めません (skew 中でも動く API パスがあるため)。**新版を上書きインストールする前に `curl -X POST http://127.0.0.1:54321/api/worker/shutdown` で古い worker を停止することを推奨** (詳細: [docs/version-handshake.md](docs/version-handshake.md))。
+- **`custom_groups` キーが無い既存 `queue_config.json`**: 完全互換。`custom_groups` は空 dict 扱いとなり、すべての endpoint がカテゴリ経由でルーティングされます (lazy-v2.10.x と同じ挙動)。新規インストールでは Seedance v2.0 動画モデル群 (`t2v_sd2` / `i2v_sd2` / `r2v_sd2`) が初期同梱されます — 既存ユーザーが Seedance v2.0 モデルを使う場合は `queue_config.json` に手動で追加するか、新規スキル生成 (`generate_skill.py`) を流すと反映されます。
+- **lazy-v2.10.x dashboard との組み合わせ**: dashboard は `custom_groups` セクションを表示しませんが、worker の HTTP API は引き続き動作します。`/api/config` の `custom_groups` フィールドは旧 dashboard には無視されるため、`category_rate_limits` の旧互換ミラーキーと同じく "ignore unknown fields" 戦略で安全に共存します。
 
 ## [lazy-v2.10.0](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/releases/tag/lazy-v2.10.0) (2026-04-23)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Claude Code用のMCPスキルジェネレーター。非同期ジョブパター
 | **キュー堅牢化** | ゾンビジョブ回復・指数バックオフリトライ・429 Retry-After対応・ワーカー側ダウンロード | 自動 | [📖](docs/queue_system_hardening.md) |
 | **カテゴリ別制御** | t2i/i2i/t2v/i2vカテゴリ単位でのinflight制御・429自動リトライ・非429エラー時のカテゴリ即pause | 自動 | [📖](docs/category-limits.md) |
 | **per-category 個別レートリミット** | 各カテゴリに独立した max_inflight / min_interval / exhaust_cooldown を設定可能 (`limits.{cat}.{key}`)。サービス側のカテゴリ別レートリミットに合わせて調整 | `queue_config.json` | [📖](docs/category-limits.md) |
+| **Custom Groups** | endpoint URL パターン (glob) で独自グループを定義し、カテゴリと独立にレートリミット。Bytedance Seedance v2.0 動画モデルが既定で同梱 (`t2v_sd2` / `i2v_sd2` / `r2v_sd2`) | `queue_config.json` | [📖](docs/custom-groups.md) |
 | **Worker version handshake** | 上書きインストールで古い worker daemon が残った場合に stderr で 1 回警告。`X-Worker-Version` ヘッダー + `GET /api/version` | 自動 | [📖](docs/version-handshake.md) |
 | **DB スキーマ migration 基盤** | `PRAGMA user_version` ベースの簡易マイグレーション。Phase 1 では足場のみ追加 (実カラム変更は将来 migration で対応) | 自動 | [📖](docs/db-migration.md) |
 | **セッション管理** | MCPセッションをendpoint単位でキャッシュ。認証サーバーへの負荷を削減 | 自動 | |
@@ -582,12 +583,41 @@ python mcp_async_call.py --resume-category t2i
       "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
     }
   },
+  "custom_groups": {
+    "t2v_sd2": {
+      "endpoints": [
+        "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0",
+        "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0-fast"
+      ],
+      "max_inflight": 1,
+      "min_interval": 10,
+      "exhaust_cooldown": 3600
+    },
+    "i2v_sd2": {
+      "endpoints": [
+        "https://kamui-code.ai/i2v_sd2/fal/bytedance/seedance-v2.0",
+        "https://kamui-code.ai/i2v_sd2/fal/bytedance/seedance-v2.0-fast"
+      ],
+      "max_inflight": 1,
+      "min_interval": 10,
+      "exhaust_cooldown": 3600
+    },
+    "r2v_sd2": {
+      "endpoints": [
+        "https://kamui-code.ai/r2v_sd2/fal/bytedance/seedance-v2.0-reference",
+        "https://kamui-code.ai/r2v_sd2/fal/bytedance/seedance-v2.0-fast-reference"
+      ],
+      "max_inflight": 1,
+      "min_interval": 10,
+      "exhaust_cooldown": 3600
+    }
+  },
   "job_retention_seconds": 86400,
   "results_dir": ".claude/queue/results"
 }
 ```
 
-> 📖 詳細: [キューシステム設計](docs/queue_system_design.md) / [堅牢化設計](docs/queue_system_hardening.md) / [カテゴリ別レートリミット (per-category limits)](docs/category-limits.md)
+> 📖 詳細: [キューシステム設計](docs/queue_system_design.md) / [堅牢化設計](docs/queue_system_hardening.md) / [カテゴリ別レートリミット (per-category limits)](docs/category-limits.md) / [Custom Groups (endpoint-pattern rate limiting)](docs/custom-groups.md)
 
 ## エラーハンドリング
 

--- a/docs/custom-groups.md
+++ b/docs/custom-groups.md
@@ -1,0 +1,282 @@
+# Custom Groups (Endpoint-Pattern Rate Limiting)
+
+`lazy-v2.11.0` 以降、`category_rate_limits` (`t2i` / `i2i` / `t2v` / `i2v` カテゴリ単位の制御) に加えて、**ユーザーが endpoint パターンで定義する独自グループ** に対しても per-group の同時実行数 / インターバル / 429 cooldown を設定できます。
+
+## なぜ必要か
+
+カテゴリ別レートリミット ([per-category limits](category-limits.md)) は「サービスの利用形態 (テキスト→画像 / 画像→画像 / テキスト→動画 / 画像→動画)」という粗い粒度で十分機能します。一方で、上流の MCP サービスは **特定の高コストモデル群だけを別枠で絞る** 運用をしているケースがあります：
+
+- Bytedance Seedance v2.0 の動画モデル群は `t2v` / `i2v` の通常モデルとは独立したクオータで管理されている
+- 同じ `t2v` カテゴリでも、Veo3 のような high-tier モデルは別枠
+- ユーザー独自の事情で「特定モデルだけ絞りたい」「特定モデルだけ並列度を上げたい」
+
+これらをカテゴリ単位で表現すると、以下のいずれかの問題が起きます：
+
+1. **カテゴリ全体を厳しく絞る** → 安価なモデルまで巻き込まれて待たされる
+2. **カテゴリ全体を緩める** → 高コストモデルが上流レートリミットを踏んで 429 連発
+
+`custom_groups` はこの間を埋める仕組みです。glob パターンで対象 endpoint を選び、その群だけ独立した limiter を持たせます。**マッチした群はカテゴリ計上から完全に除外** されるので、ダブルカウントによる過剰絞りも起きません。
+
+## 設定スキーマ (`queue_config.json`)
+
+```json
+{
+  "custom_groups": {
+    "t2v_sd2": {
+      "endpoints": [
+        "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0",
+        "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0-fast"
+      ],
+      "max_inflight": 1,
+      "min_interval": 10,
+      "exhaust_cooldown": 3600
+    },
+    "premium-video": {
+      "endpoints": ["https://kamui-code.ai/t2v/fal/veo3*"],
+      "max_inflight": 1,
+      "min_interval": 30,
+      "exhaust_cooldown": 7200
+    }
+  }
+}
+```
+
+各キー：
+
+| キー | 意味 | 既定値 (key 未指定時) |
+|---|---|---|
+| `endpoints` | マッチさせる endpoint URL の glob パターン (fnmatch ベース、case-sensitive)。配列で複数指定可 | **必須**（空配列 / 未指定はそのグループを無視） |
+| `max_inflight` | 同時に submit 中にできるジョブ数 | `1` |
+| `min_interval` | 同グループ内の submit 間隔 (秒) | `1.0` |
+| `exhaust_cooldown` | 429 を 1 回受けた後にグループ全体を抑制する秒数 | `3600` |
+
+### Glob パターン
+
+- `fnmatch.fnmatchcase` ベース。**大文字小文字を区別** します（URL は実運用上 case-sensitive のため）
+- ワイルドカード: `*` (任意の文字列)、`?` (任意の 1 文字)、`[abc]` (文字クラス)
+- パスの `/` を特別扱いしません — 普通の文字としてマッチングされます
+
+例：
+
+| パターン | マッチする例 | しない例 |
+|---|---|---|
+| `https://kamui-code.ai/t2v/fal/veo3*` | `.../veo3`, `.../veo3-fast`, `.../veo3-pro` | `.../veo` |
+| `*/seedance*` | 任意のホスト下の `seedance*` | `seedanceX` の前に `/` がない URL |
+| `https://api.example.com/*` | 当該ホスト配下の任意 path | 別ホスト |
+
+### マッチング順序: First-Match-Wins
+
+複数の群が同じ endpoint にマッチする可能性がある場合、**`queue_config.json` での宣言順で最初にマッチした群が採用** されます。Python 3.7+ で `dict` の挿入順が保証されるため、JSON での記述順 = Python での走査順です。
+
+```json
+{
+  "custom_groups": {
+    "specific": {
+      "endpoints": ["https://kamui-code.ai/t2v/fal/veo3-pro"],
+      "max_inflight": 1
+    },
+    "broad": {
+      "endpoints": ["https://kamui-code.ai/t2v/*"],
+      "max_inflight": 5
+    }
+  }
+}
+```
+
+→ `https://kamui-code.ai/t2v/fal/veo3-pro` は **`specific` 群** に割り当てられます (`broad` も match するが、宣言順で `specific` が先)。
+
+### Group 名の制約
+
+- HTTP API (`POST /api/groups/{name}/{action}`) の URL path に直接埋め込むため、**simple token (英数 + `-` + `_`) を推奨** します
+- `/`, 空白, `?`, `#` 等は API path として扱いにくいので避けてください
+- 内部的にはどんな文字でも config 上は使えますが、HTTP API 経由の操作ができなくなります
+
+## カテゴリとの関係: マッチした群はカテゴリから完全除外
+
+設計上の重要ポイントです。
+
+```
+endpoint = https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0
+
+  Step 1: custom_groups にマッチするか?
+    YES → 群の limiter を使う、カテゴリ計上には含めない
+    NO  ↓
+  Step 2: extract_category() で category prefix を取得
+    マッチ → category limiter を使う
+    None  → 何の rate limit も適用しない (dispatcher は throttle なしで dispatch)
+```
+
+これにより、`t2v_sd2` 群にマッチした endpoint の 429 / inflight は **`t2v` カテゴリのカウンタには加算されません**。`t2v_sd2` を厳しく絞っても、別の通常 `t2v` モデル (例: `wan-25-preview`) の dispatch には影響しません。
+
+## 同梱されているデフォルト群
+
+`lazy-v2.11.0` 以降の新規スキル生成 (`generate_skill.py`) と `queue_config.example.json` には、Bytedance Seedance v2.0 動画モデル群が **デフォルトで同梱** されます：
+
+| 群名 | 対象 endpoint | max_inflight | min_interval | exhaust_cooldown |
+|---|---|---|---|---|
+| `t2v_sd2` | `seedance-v2.0` / `seedance-v2.0-fast` | 1 | 10s | 3600s |
+| `i2v_sd2` | `seedance-v2.0` / `seedance-v2.0-fast` | 1 | 10s | 3600s |
+| `r2v_sd2` | `seedance-v2.0-reference` / `seedance-v2.0-fast-reference` | 1 | 10s | 3600s |
+
+なぜ初期同梱かというと、**URL prefix `t2v_sd2` / `i2v_sd2` / `r2v_sd2` が標準カテゴリリスト (`t2i / i2i / t2v / i2v`) に含まれない** ため、`custom_groups` 設定なしでは「未知 endpoint」扱いとなり、dispatcher が rate-limit accounting を一切スキップしてしまうからです。高コストモデルがレートリミットなしで野放しになるのは安全とは言えないため、保守的なデフォルトを最初から入れています。
+
+これらの値は実運用での挙動を見て自由に調整してください。
+
+## Runtime API
+
+実行中の worker に対して `PATCH /api/config` で per-group 値を変更できます。
+
+### 群の状態取得 (`GET /api/groups`)
+
+#### bash
+
+```bash
+curl http://127.0.0.1:54321/api/groups
+```
+
+#### PowerShell
+
+```powershell
+Invoke-RestMethod -Uri "http://127.0.0.1:54321/api/groups" | ConvertTo-Json -Depth 5
+```
+
+レスポンス例：
+
+```json
+{
+  "server_time_utc": "2026-05-10T07:30:00.000000Z",
+  "groups": {
+    "t2v_sd2": {
+      "endpoints": [
+        "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0",
+        "https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0-fast"
+      ],
+      "paused": false,
+      "inflight": 0,
+      "max_inflight": 1,
+      "min_interval": 10,
+      "exhaust_cooldown": 3600,
+      "consecutive_429": 0,
+      "cooldown_remaining_s": 0
+    },
+    "i2v_sd2": { ... },
+    "r2v_sd2": { ... }
+  }
+}
+```
+
+### Per-group 値の runtime 変更 (`PATCH /api/config`)
+
+#### bash
+
+```bash
+# 1 つの群の max_inflight を変更
+curl -X PATCH http://127.0.0.1:54321/api/config \
+  -H 'Content-Type: application/json' \
+  -d '{"groups": {"t2v_sd2": {"max_inflight": 2}}}'
+
+# 複数群を同時に更新
+curl -X PATCH http://127.0.0.1:54321/api/config \
+  -H 'Content-Type: application/json' \
+  -d '{"groups": {
+    "t2v_sd2": {"max_inflight": 2, "exhaust_cooldown": 1800},
+    "i2v_sd2": {"max_inflight": 2}
+  }}'
+```
+
+#### PowerShell
+
+```powershell
+Invoke-RestMethod -Method Patch `
+  -Uri "http://127.0.0.1:54321/api/config" `
+  -Body (@{
+      groups = @{
+          t2v_sd2 = @{ max_inflight = 2; exhaust_cooldown = 1800 }
+          i2v_sd2 = @{ max_inflight = 2 }
+      }
+  } | ConvertTo-Json -Depth 5) `
+  -ContentType "application/json"
+```
+
+レスポンス例：
+
+```json
+{
+  "applied": {
+    "groups.t2v_sd2.max_inflight": 2,
+    "groups.t2v_sd2.exhaust_cooldown": 1800,
+    "groups.i2v_sd2.max_inflight": 2
+  },
+  "rejected": {},
+  "requires_restart": []
+}
+```
+
+### 群の手動 pause / resume
+
+サービス障害時や緊急停止用：
+
+#### bash
+
+```bash
+# pause
+curl -X POST http://127.0.0.1:54321/api/groups/t2v_sd2/pause
+
+# resume
+curl -X POST http://127.0.0.1:54321/api/groups/t2v_sd2/resume
+```
+
+#### PowerShell
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://127.0.0.1:54321/api/groups/t2v_sd2/pause"
+Invoke-RestMethod -Method Post -Uri "http://127.0.0.1:54321/api/groups/t2v_sd2/resume"
+```
+
+未知の群名を指定した場合は **404** が返り、レスポンス本文に `available_groups` リストが含まれます：
+
+```json
+{
+  "error": "Unknown group: nonexistent",
+  "available_groups": ["t2v_sd2", "i2v_sd2", "r2v_sd2"]
+}
+```
+
+### 入力検証
+
+`PATCH /api/config` の `groups` 値は dict 必須です。`null` / `int` / `list` / `string` 等は reject されます (per-category と同じパターン)：
+
+```bash
+# 拒否される例
+curl -X PATCH http://127.0.0.1:54321/api/config \
+  -H 'Content-Type: application/json' \
+  -d '{"groups": [1, 2, 3]}'
+# → rejected: {"groups": "must be object (got list)"}
+
+# 未知の群名も reject
+curl -X PATCH http://127.0.0.1:54321/api/config \
+  -H 'Content-Type: application/json' \
+  -d '{"groups": {"nonexistent": {"max_inflight": 1}}}'
+# → rejected: {"groups.nonexistent": "unknown group"}
+```
+
+## 後方互換マトリクス
+
+| 利用者の状態 | queue_config | dispatcher | 動作 |
+|---|---|---|---|
+| **新規インストール** | デフォルトで Seedance v2.0 群が入っている | 新 (v2.11.0+) | 高コストモデルが最初から rate-limited |
+| **lazy-v2.10.x からアップグレード、`queue_config.json` を手動で残した** | `custom_groups` キーが無い | 新 (v2.11.0+) | `custom_groups` は空 dict 扱い、全 endpoint がカテゴリ経由 (= 従来通り) |
+| **lazy-v2.10.x dashboard を使い続ける** | (任意) | 新 (v2.11.0+) | dashboard は `custom_groups` を表示しないが、worker 側は問題なく動作 |
+
+`custom_groups` の追加は **完全に opt-in** です。既存の `queue_config.json` に `custom_groups` キーを追加しなくても、PR1 で導入された per-category limits だけで動作し続けます。
+
+## 設計判断ログ
+
+PR4 (#60) で議論し決定した仕様：
+
+- **群が category を完全 bypass する**: マッチした endpoint は群の limiter だけで accounting される。カテゴリにも同時加算するとダブルカウントになり、ユーザーの直感 (「群を独立に管理したい」) に反する
+- **First-match-wins (宣言順)**: 同じ endpoint が複数群にマッチする可能性がある場合、宣言順で勝ち。Python 3.7+ の dict 挿入順保証に依存。優先度を変えたいときは config ファイル内で群の宣言順を入れ替える
+- **未知の群名は 404**: HTTP API として典型的な扱い。`available_groups` リストを同時に返してデバッグを楽にする
+- **`PATCH /api/config` の `groups` 値は dict 必須**: per-category と同じ contract。`null` / `int` 等を silent に通すと設定ミスを見逃すため
+- **状態管理は `LimiterStateMixin` で `CategoryLimiter` と共有**: inflight / 429 cooldown / pause/resume の挙動が両者で完全に同じであることを保証。バグ修正・拡張が一箇所で済む
+- **`_match_cache` の lock 内化 (PHASE1_PLAN_v3 fix #13)**: glob マッチング結果をキャッシュするが、複数 dispatcher thread からの同時 read/write を保証するため `_lock` 内で操作。`_SENTINEL` で「未計算」と「キャッシュ済み None」を区別


### PR DESCRIPTION
## Summary

Closes #60 (Phase 1 PR4, targeting `lazy-v2.11.0` alongside #59 / #62 / #63).

**Status: draft** — implementation + tests are landed; docs / CHANGELOG / README updates are coming as a follow-up commit on this same branch.

The upstream MCP service applies extra, narrower rate limits to certain high-cost models (e.g. video models priced higher than text-to-image). \`custom_groups\` lets users mirror that on the client by declaring endpoint-pattern groups in \`queue_config.json\`, each with its own \`max_inflight\` / \`min_interval\` / \`exhaust_cooldown\`. A group match overrides the per-category accounting so the parent category isn't double-charged.

## What changes

### Wire format

\`\`\`json
{
  \"custom_groups\": {
    \"premium-video\": {
      \"endpoints\": [
        \"https://kamui-code.ai/t2v/fal/veo3*\",
        \"https://kamui-code.ai/i2v/fal/veo3*\"
      ],
      \"max_inflight\": 1,
      \"min_interval\": 30,
      \"exhaust_cooldown\": 7200
    }
  }
}
\`\`\`

- Glob (\`fnmatch\`) patterns, case-sensitive.
- First-match-wins ordering uses Python 3.7+ dict insertion order = wire-format declaration order.
- Empty / absent \`custom_groups\` block = no-op (everything routes through CategoryLimiter, identical to pre-PR4 behaviour).

### New API endpoints

- \`GET /api/groups\` — runtime status of every configured group (endpoints, inflight, cooldown, paused, 429 counter).
- \`GET /api/config\` — now includes a \`custom_groups\` block alongside the existing \`category\` block. The PR1 legacy mirror keys on \`category\` are unchanged.
- \`GET /api/stats\` — now includes a \`custom_groups\` section alongside \`category_limits\`.
- \`POST /api/groups/{name}/{pause|resume}\` — symmetric with \`/api/categories/{cat}/{action}\`. Unknown group → 404 with \`available_groups\` listed; invalid action → 400.
- \`PATCH /api/config\` accepts a top-level \`groups\` block: \`{\"groups\": {\"name\": {\"max_inflight\": N}}}\`. Same validation pattern as \`category.limits.{cat}.{key}\`.

### Internal refactor — LimiterStateMixin

Inflight / 429 cooldown / pause / 429-counter primitives moved into a new \`job_queue/limiter_state.py\`, shared by CategoryLimiter and CustomGroupLimiter. Bug fixes there apply to both limiters at once.

CategoryLimiter's public API is **unchanged** — the 55 PR1 tests pass without modification. The only observable change is that the dispatcher now reaches the limiter through \`Dispatcher._resolve_limiter()\` (which picks group OR category) rather than directly touching \`self.category_limiter\`. \`(None, None)\` from \`_resolve_limiter\` means \"truly unknown endpoint\" and the dispatcher skips every per-key gate — preserving the PR1 \`TestUnknownCategoryEndpointDispatch\` contract.

### Reviewer Checklist — dispatcher 2-stage routing grep

PHASE1_PLAN_v3 fix #11 / Codex review of PR1: confirm \`_resolve_limiter()\` is the single funnel through which the dispatcher reaches the rate limiters.

\`\`\`bash
# Should print 0 lines (constructor assignments and group_limiter
# wiring through _resolve_limiter are the only allowed mentions)
rg \"category_limiter\\.\" .claude/skills/mcp-async-skill/scripts/job_queue/dispatcher.py |
  grep -v _resolve_limiter |
  grep -v \"self\\.category_limiter = \"
\`\`\`

PowerShell:

\`\`\`powershell
Select-String -Path \".claude/skills/mcp-async-skill/scripts/job_queue/dispatcher.py\" \`
              -Pattern \"category_limiter\\.\" |
    Where-Object { \$_.Line -notmatch \"_resolve_limiter\" -and \$_.Line -notmatch \"self\\.category_limiter = \" }
\`\`\`

This PR's grep is clean — the only \`category_limiter.\` references in the dispatcher are the constructor assignment and the 429 endpoint-cooldown fallback (which intentionally uses \`category_limiter.get_exhaust_cooldown(None)\` for the unknown-endpoint case where there is no resolved limiter to ask).

## Verification

\`\`\`
\$ pytest .claude/skills/mcp-async-skill/scripts/tests/ -q
398 passed in ~73s
\`\`\`

Counts:
- baseline (post-PR3 main): 335
- this PR adds: +63 (\`test_custom_group_limiter.py\` 35 + \`test_dispatcher_groups.py\` 12 + \`test_worker_groups.py\` 16)
- final: 398

### Test coverage highlights

- \`test_extract_group_concurrent_smoke\` (PHASE1_PLAN_v3 fix #13): 8 threads × 800 lookups against the same limiter — catches a regression that drops the \`_match_cache\` lock.
- \`test_group_endpoint_creates_no_category_inflight\`: a 429 from a group-matched endpoint charges the group counter, NOT the parent category counter. This is the headline behaviour custom_groups exists to provide.
- \`test_unknown_endpoint_dispatches\`: PR1 \`TestUnknownCategoryEndpointDispatch\` contract preserved across the dispatcher refactor.
- \`test_warning_mentions_group_when_group_is_paused\` / \`test_warning_mentions_category_when_category_is_paused\`: the \`POST /api/jobs\` pause warning text reflects the resolved limiter, never disagreeing with dispatch routing.

## Test plan

- [x] \`pytest .claude/skills/mcp-async-skill/scripts/tests/ -q\` → 398 passed
- [x] CategoryLimiter PR1 tests (55) pass without modification → confirms public API intact
- [x] grep checklist for \`_resolve_limiter\` exclusivity → clean
- [ ] **Docs follow-up commit** (planned on this branch before un-drafting): \`docs/custom-groups.md\`, README feature row, CHANGELOG \`[Unreleased]\` entry
- [ ] Manual: configure a \`premium-video\` group, submit a job to a matching endpoint, confirm \`GET /api/groups\` shows inflight=1 and \`GET /api/categories\` shows the parent category's inflight=0
- [ ] Manual: \`POST /api/groups/premium-video/pause\` → confirm subsequent submissions return the group-paused warning

## Out of scope

- Dashboard UI for custom_groups (PR5 / #61, on this same v2.11.0 release train).
- Cross-limiter shared cooldown helpers (deferred to Phase 2 — the Mixin gives us a clean place to add them later if needed).

## Reviewing this PR

Suggested commit-by-commit reading order:

1. \`42b904c\` refactor: LimiterStateMixin extraction + CategoryLimiter inheriting it. Public API unchanged, behaviour-preserving.
2. \`a95a79f\` feat: CustomGroupLimiter, dispatcher \`_resolve_limiter\`, worker API endpoints, generate_skill template, queue_config example.
3. \`4e12000\` test: 63 new tests covering construction, glob matching, concurrent smoke, dispatcher integration, HTTP API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)