### PR TITLE
feat(dashboard): per-category UI + Custom Groups + --port 0 + graceful degrade (#61, #53)

### DIFF
--- a/.claude/skills/mcp-async-skill/scripts/tests/test_dashboard_smoke.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_dashboard_smoke.py
@@ -1,0 +1,323 @@
+# -*- coding: utf-8 -*-
+"""Smoke tests for queue_dashboard (PR5 / #61 + #53).
+
+The dashboard ships its own ``queue_dashboard.py`` entry point under
+``.claude/skills/queue-dashboard/``. The two behaviours we need to pin
+across releases live there:
+
+1. ``--port 0`` (#53): when the user passes ``--port 0`` the OS picks
+   a free port and the dashboard prints a ``PORT=NNNNN`` line on
+   stdout. Tooling parses that line to know where to point a browser.
+2. The proxy whitelist (PR5): ``/api/groups``, ``/api/version``, and
+   ``POST /api/groups/{name}/{pause|resume}`` reach the worker. The
+   pre-PR5 dashboard would 404 these because they were missing from
+   ALLOWED_GET / ALLOWED_POST.
+
+Both are integration-shaped (subprocess + HTTP) but cheap because we
+run them against a mock worker on a random port and tear them down
+inside the test.
+"""
+import os
+import re
+import socket
+import subprocess
+import sys
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import requests
+
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..")
+)
+DASHBOARD_PY = os.path.join(
+    REPO_ROOT,
+    ".claude", "skills", "queue-dashboard", "scripts", "queue_dashboard.py",
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _MockWorkerHandler(BaseHTTPRequestHandler):
+    """Records every proxied request so tests can assert pass-through."""
+
+    received_paths: list[str] = []
+
+    def log_message(self, format, *args):
+        # Suppress default access-log noise in test output.
+        pass
+
+    def _send(self, status: int, body: dict):
+        import json as _json
+        data = _json.dumps(body).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        # Mimic the worker's PR2 X-Worker-Version header so the
+        # dashboard's loadConfig() can read it back.
+        self.send_header("X-Worker-Version", "test-worker-v9.9.9")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        type(self).received_paths.append(("GET", self.path))
+        if self.path == "/api/version":
+            self._send(200, {
+                "version": "test-worker-v9.9.9",
+                "api_compatible_versions": ["test-worker-v9.9.9"],
+                "server_time_utc": "2026-05-10T00:00:00.000000Z",
+            })
+            return
+        if self.path == "/api/groups":
+            self._send(200, {
+                "server_time_utc": "2026-05-10T00:00:00.000000Z",
+                "groups": {
+                    "premium-video": {
+                        "endpoints": ["https://kamui-code.ai/t2v/fal/veo3*"],
+                        "max_inflight": 1,
+                        "min_interval": 30,
+                        "exhaust_cooldown": 7200,
+                        "paused": False,
+                        "inflight": 0,
+                        "consecutive_429": 0,
+                        "cooldown_remaining_s": 0,
+                    },
+                },
+            })
+            return
+        if self.path == "/api/health":
+            self._send(200, {"status": "ok"})
+            return
+        self._send(404, {"error": "not found"})
+
+    def do_POST(self):
+        type(self).received_paths.append(("POST", self.path))
+        if self.path.startswith("/api/groups/"):
+            # Whitelist check is what we really care about here.
+            self._send(200, {"group": "premium-video", "paused": True})
+            return
+        self._send(404, {"error": "not found"})
+
+
+class _MockWorker:
+    """Background HTTP server playing the worker's role."""
+
+    def __init__(self):
+        self.port = _free_port()
+        # Each test gets its own subclass so received_paths doesn't bleed
+        # between tests in the same process.
+        self.handler_cls = type(
+            "Handler", (_MockWorkerHandler,), {"received_paths": []},
+        )
+        self.server = HTTPServer(("127.0.0.1", self.port), self.handler_cls)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def start(self):
+        self.thread.start()
+
+    def stop(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+
+class _DashboardSubprocess:
+    """Launches queue_dashboard.py as a subprocess and parses its
+    ``PORT=NNNNN`` line out of stdout."""
+
+    def __init__(self, worker_url: str, requested_port: int = 0):
+        self.worker_url = worker_url
+        self.requested_port = requested_port
+        self.proc: subprocess.Popen | None = None
+        self.actual_port: int | None = None
+
+    def start(self, deadline_s: float = 10.0):
+        cmd = [
+            sys.executable, DASHBOARD_PY,
+            "--port", str(self.requested_port),
+            "--worker-url", self.worker_url,
+            "--no-open",
+        ]
+        # Force UTF-8 for the subprocess's stdout/stderr so reading the
+        # 'PORT=NNNNN' line doesn't crash on Windows when the dashboard
+        # logs a non-ASCII path (typical on this repo's Windows
+        # checkouts where the project root contains Japanese
+        # characters). cp932 + 0x87 is what the previous run hit.
+        env = os.environ.copy()
+        env.setdefault("PYTHONIOENCODING", "utf-8")
+        self.proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+        )
+        # Read stdout line-by-line until we see the PORT= line.
+        deadline = time.monotonic() + deadline_s
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                # Already exited — surface stdout to make the failure
+                # message useful.
+                remaining = self.proc.stdout.read() if self.proc.stdout else ""
+                raise RuntimeError(
+                    f"queue_dashboard exited with code {self.proc.returncode} "
+                    f"before announcing port. Output:\n{remaining}"
+                )
+            line = self.proc.stdout.readline()
+            if not line:
+                time.sleep(0.05)
+                continue
+            m = re.match(r"PORT=(\d+)", line.strip())
+            if m:
+                self.actual_port = int(m.group(1))
+                return
+        raise TimeoutError(
+            "queue_dashboard did not print 'PORT=NNNNN' within "
+            f"{deadline_s}s"
+        )
+
+    def stop(self):
+        if self.proc is None:
+            return
+        if self.proc.poll() is None:
+            try:
+                self.proc.terminate()
+                self.proc.wait(timeout=5)
+            except Exception:
+                self.proc.kill()
+                self.proc.wait()
+
+    @property
+    def url(self) -> str:
+        if self.actual_port is None:
+            raise RuntimeError("Dashboard hasn't started yet")
+        return f"http://127.0.0.1:{self.actual_port}"
+
+
+@unittest.skipUnless(
+    os.path.isfile(DASHBOARD_PY),
+    f"queue_dashboard.py not found at {DASHBOARD_PY}",
+)
+class TestPortZeroAllocation(unittest.TestCase):
+    """PR5 (#53): ``--port 0`` makes the OS pick a free port. The
+    dashboard prints ``PORT=NNNNN`` on stdout so a calling script can
+    parse it without guessing or racing on the default 54322."""
+
+    def test_dashboard_with_port_zero_announces_actual_port(self):
+        worker = _MockWorker()
+        worker.start()
+        try:
+            dashboard = _DashboardSubprocess(worker.url, requested_port=0)
+            try:
+                dashboard.start()
+                # ``actual_port`` must be a valid TCP port and not 0.
+                self.assertIsNotNone(dashboard.actual_port)
+                self.assertGreater(dashboard.actual_port, 0)
+                self.assertLessEqual(dashboard.actual_port, 65535)
+
+                # Sanity: the dashboard actually serves on that port.
+                resp = requests.get(f"{dashboard.url}/api/health", timeout=3)
+                self.assertEqual(resp.status_code, 200)
+            finally:
+                dashboard.stop()
+        finally:
+            worker.stop()
+
+
+@unittest.skipUnless(
+    os.path.isfile(DASHBOARD_PY),
+    f"queue_dashboard.py not found at {DASHBOARD_PY}",
+)
+class TestProxyWhitelist(unittest.TestCase):
+    """PR5 (#61): ``/api/groups``, ``/api/version``, and group
+    pause/resume endpoints are whitelisted in queue_dashboard.py and
+    therefore reach the (mock) worker. A regression that drops them
+    from ALLOWED_GET / ALLOWED_POST would surface as a 404 from the
+    dashboard before the worker is consulted at all."""
+
+    def setUp(self):
+        self.worker = _MockWorker()
+        self.worker.start()
+        self.dashboard = _DashboardSubprocess(self.worker.url, requested_port=0)
+        self.dashboard.start()
+
+    def tearDown(self):
+        self.dashboard.stop()
+        self.worker.stop()
+
+    def _get(self, path: str) -> requests.Response:
+        return requests.get(self.dashboard.url + path, timeout=3)
+
+    def _post(self, path: str) -> requests.Response:
+        return requests.post(self.dashboard.url + path, timeout=3)
+
+    def test_get_api_version_proxies_to_worker(self):
+        resp = self._get("/api/version")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["version"], "test-worker-v9.9.9")
+        # Confirm the worker actually saw the request (i.e. dashboard
+        # didn't 404 before forwarding).
+        self.assertIn(("GET", "/api/version"),
+                      self.worker.handler_cls.received_paths)
+
+    def test_get_api_groups_proxies_to_worker(self):
+        resp = self._get("/api/groups")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertIn("groups", body)
+        self.assertIn(("GET", "/api/groups"),
+                      self.worker.handler_cls.received_paths)
+
+    def test_post_api_groups_pause_proxies_to_worker(self):
+        resp = self._post("/api/groups/premium-video/pause")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(("POST", "/api/groups/premium-video/pause"),
+                      self.worker.handler_cls.received_paths)
+
+    def test_post_api_groups_resume_proxies_to_worker(self):
+        resp = self._post("/api/groups/premium-video/resume")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(("POST", "/api/groups/premium-video/resume"),
+                      self.worker.handler_cls.received_paths)
+
+    def test_post_api_groups_with_dotted_name_proxies(self):
+        """The ALLOWED_POST regex permits ``[A-Za-z0-9_\\-.]+`` so a
+        group named ``foo.bar`` survives the whitelist. Don't break
+        this without intent — the worker's group name validation is
+        more lenient than this regex on purpose."""
+        resp = self._post("/api/groups/foo.bar/pause")
+        # Dashboard whitelist OK → request reaches our mock worker
+        self.assertIn(("POST", "/api/groups/foo.bar/pause"),
+                      self.worker.handler_cls.received_paths)
+
+    def test_post_to_unknown_path_is_blocked_locally(self):
+        """Sanity: requests outside the whitelist do NOT reach the
+        worker. The dashboard short-circuits with 403 / 404 / 405
+        (any non-2xx is fine — the assertion that matters is that
+        the worker never saw it)."""
+        before = list(self.worker.handler_cls.received_paths)
+        resp = self._post("/api/totally-bogus")
+        # Anything in the 4xx range proves the dashboard refused to
+        # forward; the exact code is an implementation detail.
+        self.assertGreaterEqual(resp.status_code, 400)
+        self.assertLess(resp.status_code, 500)
+        # Worker never saw it
+        self.assertEqual(self.worker.handler_cls.received_paths, before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/queue-dashboard/SKILL.md
+++ b/.claude/skills/queue-dashboard/SKILL.md
@@ -12,8 +12,9 @@ Browser-based dashboard for the MCP job queue, built with Python stdlib + Vanill
 - Monitoring queue status in real time
 - Inspecting pending / running / completed / failed jobs at a glance
 - Debugging failed jobs (view full error details with args)
-- Pausing / resuming categories (t2i / i2i / t2v / i2v)
-- Confirming that rate limiting is behaving as expected
+- Pausing / resuming categories (t2i / i2i / t2v / i2v) AND custom groups
+- Confirming that per-category and per-group rate limiting is behaving as expected
+- Tuning per-category and per-group limits (`max_inflight`, `min_interval`, `exhaust_cooldown`) at runtime via the Settings panel
 
 ## How to Start
 
@@ -26,15 +27,35 @@ python .claude/skills/queue-dashboard/scripts/queue_dashboard.py
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--port` | 54322 | Dashboard HTTP port |
+| `--port` | 54322 | Dashboard HTTP port. **Pass `0` to let the OS pick a free port** when the default conflicts with another service. The actual port is printed on stdout as `PORT=NNNNN` (machine-parseable) followed by the human-readable URL. |
 | `--worker-url` | `http://127.0.0.1:54321` | Worker API base URL |
 | `--no-open` | false | Do not auto-open the browser |
 | `--host` | 127.0.0.1 | Bind address (external binding requires explicit change) |
+
+#### Example: dynamic port allocation
+
+```bash
+$ python .claude/skills/queue-dashboard/scripts/queue_dashboard.py --port 0 --no-open
+PORT=49152
+[Queue Dashboard] http://127.0.0.1:49152/
+[Queue Dashboard] Worker API: http://127.0.0.1:54321
+[Queue Dashboard] Project root: ...
+  Ctrl+C to stop
+```
+
+A subprocess driver can grep for `^PORT=` in stdout to discover where the dashboard bound.
 
 ## Features
 
 - **Summary cards**: pending / running / completed / failed counts
 - **Category cards**: inflight, cooldown remaining, consecutive 429s, pause reason, pause/resume buttons
+- **Custom Groups cards** *(lazy-v2.11.0+)*: same shape as Category cards, side-by-side in a two-column layout. Shows the matched endpoint patterns inline so you can confirm WHICH group is throttling a given URL. Pause/resume routes through `POST /api/groups/{name}/{action}`.
+- **Settings panel** *(lazy-v2.11.0+)*:
+  - **Per-category limits grid** — one row per t2i/i2i/t2v/i2v with `max_inflight` / `min_interval` / `exhaust_cooldown` inputs. Replaces the pre-PR1 single trio of inputs.
+  - **Custom Groups limits grid** — one row per configured group. Group names are shown with the matched endpoint patterns as a tooltip.
+  - Endpoint defaults + Worker idle timeout (unchanged from earlier versions).
+- **Worker version label**: header shows whatever `/api/version` returned (PR2). Falls back to `(pre-v2.11.0)` when the worker pre-dates the version handshake endpoint.
+- **Compatibility banner** *(lazy-v2.11.0+)*: when the worker is too old (no `cfg.category.limits`), the Settings panel shows a graceful-degrade banner with the exact `curl` to recover. The jobs list and stats continue to function.
 - **Endpoint statistics table**: per-endpoint job counts
 - **Recent jobs list**: status badges, filter by status, click-to-detail modal
 - **Job detail modal**: full JSON including original args and error body
@@ -53,8 +74,9 @@ Keeping the browser, static assets, and API on a single origin avoids CORS issue
 ### Security & Safety
 
 - **Path whitelist**: only known endpoints are proxied
-  - GET: `/api/health`, `/api/stats`, `/api/categories`, `/api/jobs`, `/api/jobs/{id}`
-  - POST: `/api/categories/{t2i|i2i|t2v|i2v|r2i|r2v}/{pause|resume}`
+  - GET: `/api/health`, `/api/stats`, `/api/categories`, `/api/groups`, `/api/config`, `/api/version`, `/api/worker/status`, `/api/jobs`, `/api/jobs/{id}`
+  - POST: `/api/categories/{t2i|i2i|t2v|i2v|r2i|r2v}/{pause|resume}`, `/api/groups/{name}/{pause|resume}` (group `name` accepts `[A-Za-z0-9_\-.]+`), `/api/endpoints/resume`, `/api/worker/shutdown`
+  - PATCH: `/api/config`
 - **Request body cap**: 1 MiB max
 - **Upstream timeout**: 10 seconds per proxied request
 - **Default bind**: `127.0.0.1` only (external binding requires explicit `--host`)

--- a/.claude/skills/queue-dashboard/scripts/queue_dashboard.py
+++ b/.claude/skills/queue-dashboard/scripts/queue_dashboard.py
@@ -46,17 +46,31 @@ MAX_REQUEST_BODY = 1 * 1024 * 1024  # 1 MiB
 STATIC_DIR = Path(__file__).parent / "static"
 
 # ---- Whitelist of proxied API paths (to worker) ----------------------------
+# PR5 (#61) additions:
+#   GET    /api/version          — worker version handshake (PR2 / #62)
+#   GET    /api/groups           — custom_groups runtime state (PR4 / #60)
+#   POST   /api/groups/{name}/{pause|resume}
+#                                — group pause toggle. The {name} segment is
+#                                  user-defined config so we accept any
+#                                  reasonable token (alnum + - + _ + .)
+#                                  rather than a closed enum. Worker side
+#                                  rejects unknown groups with 404, so a
+#                                  bogus name reaches the user as a clear
+#                                  "available_groups" response.
 ALLOWED_GET = [
     re.compile(r"^/api/health$"),
     re.compile(r"^/api/stats$"),
     re.compile(r"^/api/categories$"),
+    re.compile(r"^/api/groups$"),
     re.compile(r"^/api/config$"),
+    re.compile(r"^/api/version$"),
     re.compile(r"^/api/worker/status$"),
     re.compile(r"^/api/jobs(\?.*)?$"),
     re.compile(r"^/api/jobs/[A-Za-z0-9_\-]+(\?.*)?$"),
 ]
 ALLOWED_POST = [
     re.compile(r"^/api/categories/(t2i|i2i|t2v|i2v|r2i|r2v)/(pause|resume)$"),
+    re.compile(r"^/api/groups/[A-Za-z0-9_\-.]+/(pause|resume)$"),
     re.compile(r"^/api/endpoints/resume$"),
     re.compile(r"^/api/worker/shutdown$"),
 ]
@@ -356,8 +370,16 @@ class ThreadingDashboardServer(socketserver.ThreadingMixIn, http.server.HTTPServ
 
 def main():
     parser = argparse.ArgumentParser(description="Queue dashboard web UI")
-    parser.add_argument("--port", type=int, default=DEFAULT_DASHBOARD_PORT,
-                        help=f"Dashboard HTTP port (default: {DEFAULT_DASHBOARD_PORT})")
+    parser.add_argument(
+        "--port", type=int, default=DEFAULT_DASHBOARD_PORT,
+        help=(
+            f"Dashboard HTTP port (default: {DEFAULT_DASHBOARD_PORT}). "
+            f"Pass 0 to let the OS allocate a free port — useful when the "
+            f"default conflicts with another local service. The actual port "
+            f"is printed to stdout in a 'PORT=NNNNN' line so callers can "
+            f"parse it programmatically."
+        ),
+    )
     parser.add_argument("--worker-url", default=DEFAULT_WORKER_URL,
                         help=f"Worker API base URL (default: {DEFAULT_WORKER_URL})")
     parser.add_argument("--no-open", action="store_true",
@@ -374,13 +396,21 @@ def main():
     DashboardHandler.worker_url = args.worker_url.rstrip("/")
     DashboardHandler.project_root = project_root
 
-    url = f"http://{args.host}:{args.port}/"
     try:
         with ThreadingDashboardServer((args.host, args.port), DashboardHandler) as httpd:
+            # PR5 (#53): when --port 0 is passed, the OS picks a free port.
+            # Surface the actual port so a caller (humans reading stdout, or
+            # a parent process parsing it) knows where to point a browser.
+            actual_port = httpd.server_address[1]
+            url = f"http://{args.host}:{actual_port}/"
+            # Machine-parseable line first, in a stable shape so a
+            # subprocess driver can grep for it.
+            print(f"PORT={actual_port}")
             print(f"[Queue Dashboard] {url}")
             print(f"[Queue Dashboard] Worker API: {DashboardHandler.worker_url}")
             print(f"[Queue Dashboard] Project root: {project_root}")
             print("  Ctrl+C to stop")
+            sys.stdout.flush()
             if not args.no_open:
                 try:
                     webbrowser.open(url)

--- a/.claude/skills/queue-dashboard/scripts/static/dashboard.css
+++ b/.claude/skills/queue-dashboard/scripts/static/dashboard.css
@@ -397,3 +397,128 @@ h2 {
   max-height: 60vh;
   overflow: auto;
 }
+
+/* ---- PR5 (#61) — Custom Groups + per-category UI + compat banner ---- */
+
+/* Two-column layout for Categories + Custom Groups */
+#categories-and-groups {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1em;
+  padding: 0 1em;
+}
+@media (max-width: 900px) {
+  #categories-and-groups {
+    grid-template-columns: 1fr;
+  }
+}
+#categories-and-groups > div {
+  min-width: 0; /* allow grid items to shrink */
+}
+
+/* Group cards reuse the category-card class but have a distinct accent
+   so users can tell at a glance which limiter is gating a job. */
+.group-card {
+  background: #1a1f29;
+  border: 1px solid #3b4252;
+  border-left: 3px solid #6366f1;
+  border-radius: 4px;
+  padding: 0.7em;
+  margin-bottom: 0.5em;
+  font-size: 0.9em;
+}
+.group-card.paused {
+  border-left-color: #d97706;
+  background: #2a1f0c;
+}
+.group-card h3 {
+  margin: 0 0 0.4em 0;
+  font-size: 1em;
+  color: #c7d2fe;
+}
+.group-card .endpoints {
+  font-size: 0.75em;
+  color: #9ca3af;
+  margin: 0.3em 0;
+  word-break: break-all;
+}
+.group-card .reason {
+  font-size: 0.7em;
+  color: #fbbf24;
+  background: #1f1709;
+  padding: 0.4em;
+  border-radius: 3px;
+  margin: 0.4em 0;
+}
+.group-card button {
+  margin-top: 0.3em;
+}
+
+/* Per-category settings grid in the panel */
+#cat-limits-grid,
+#group-limits-grid {
+  display: grid;
+  gap: 0.5em;
+}
+.cat-limits-row,
+.group-limits-row {
+  display: grid;
+  grid-template-columns: 6em repeat(3, 1fr);
+  gap: 0.4em;
+  align-items: center;
+  font-size: 0.85em;
+}
+.cat-limits-row .key-label,
+.group-limits-row .key-label {
+  font-weight: 600;
+  color: #c7d2fe;
+}
+.cat-limits-row input,
+.group-limits-row input {
+  width: 100%;
+  padding: 0.3em;
+  background: #1a1f29;
+  border: 1px solid #3b4252;
+  color: #d1d5db;
+  border-radius: 3px;
+}
+.cat-limits-grid-header,
+.group-limits-grid-header {
+  display: grid;
+  grid-template-columns: 6em repeat(3, 1fr);
+  gap: 0.4em;
+  font-size: 0.75em;
+  color: #6b7280;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid #3b4252;
+  margin-bottom: 0.3em;
+}
+
+/* Compatibility banner shown in the Settings panel */
+.compat-banner {
+  margin: 0.5em 0 1em;
+  padding: 0.7em 1em;
+  border-radius: 4px;
+  font-size: 0.85em;
+  white-space: pre-line;
+  line-height: 1.5;
+}
+.compat-banner.compat-warn {
+  background: #3a2a00;
+  border-left: 3px solid #d97706;
+  color: #fef3c7;
+}
+.compat-banner.compat-error {
+  background: #3a0000;
+  border-left: 3px solid #dc2626;
+  color: #fecaca;
+}
+
+/* Worker version label in the header */
+.worker-version {
+  font-size: 0.75em;
+  color: #9ca3af;
+  margin-left: auto;
+  padding: 0 0.5em;
+  white-space: nowrap;
+}

--- a/.claude/skills/queue-dashboard/scripts/static/dashboard.js
+++ b/.claude/skills/queue-dashboard/scripts/static/dashboard.js
@@ -41,6 +41,10 @@ async function refresh() {
     workerConnected = true;
     renderSummary(stats);
     renderCategories(stats.category_limits || {});
+    // PR5 (#61): /api/stats now ships custom_groups runtime status
+    // alongside category_limits. Old workers (pre-PR4) don't include
+    // this field; the helper degrades to "(no custom groups configured)".
+    renderCustomGroups(stats.custom_groups || {});
     renderEndpoints(stats.endpoints || []);
     renderJobs(jobs.jobs || []);
     renderClock(stats.server_time_utc);
@@ -149,6 +153,81 @@ function renderCategories(categories) {
   }
 }
 
+function renderCustomGroups(groups) {
+  // PR5 (#61): the right-hand sibling of the Categories section.
+  // ``groups`` is the ``custom_groups`` block from /api/stats — keys
+  // are user-defined group names, values are the same status shape
+  // get_all_status() emits in CustomGroupLimiter (paused, inflight,
+  // max_inflight, exhaust_cooldown, cooldown_remaining_s, endpoints,
+  // pause_reason).
+  const grid = document.getElementById("group-grid");
+  if (!grid) return; // older index.html without the section
+  grid.innerHTML = "";
+  const entries = Object.entries(groups);
+  if (entries.length === 0) {
+    grid.appendChild(el("div", {
+      class: "empty-hint",
+      text: "(no custom groups configured)",
+    }));
+    return;
+  }
+  for (const [name, info] of entries) {
+    const card = el("div", {
+      class: "group-card " + (info.paused ? "paused" : ""),
+    });
+    card.appendChild(el("h3", { text: name }));
+
+    // Endpoints — collapsed text block; users mostly want the runtime
+    // values, but seeing the patterns confirms which group is gating
+    // a given URL.
+    if (Array.isArray(info.endpoints) && info.endpoints.length > 0) {
+      card.appendChild(el("div", {
+        class: "endpoints",
+        title: info.endpoints.join("\n"),
+        text: info.endpoints.length === 1
+          ? info.endpoints[0]
+          : `${info.endpoints[0]} (+${info.endpoints.length - 1} more)`,
+      }));
+    }
+
+    card.appendChild(el("div", {
+      text: `Inflight: ${info.inflight ?? 0}/${info.max_inflight ?? 1}`,
+    }));
+    card.appendChild(el("div", {
+      text: `Cooldown: ${info.cooldown_remaining_s ?? 0}s`,
+    }));
+    card.appendChild(el("div", {
+      text: `Consec 429: ${info.consecutive_429 ?? 0}`,
+    }));
+    card.appendChild(el("div", {
+      text: info.paused ? "⏸ PAUSED" : "▶ Active",
+    }));
+    if (info.pause_reason) {
+      card.appendChild(el("pre", {
+        class: "reason",
+        text: JSON.stringify(info.pause_reason, null, 2),
+      }));
+    }
+    card.appendChild(el("button", {
+      text: info.paused ? "Resume" : "Pause",
+      onclick: () => toggleGroup(name, info.paused),
+    }));
+    grid.appendChild(card);
+  }
+}
+
+async function toggleGroup(name, currentlyPaused) {
+  const action = currentlyPaused ? "resume" : "pause";
+  try {
+    await fetchJSON(`/api/groups/${encodeURIComponent(name)}/${action}`, { method: "POST" });
+    refresh();
+  } catch (e) {
+    // Worker returns 404 with available_groups for unknown name — surface
+    // the message as-is so the user can see the typo / missing group.
+    setStatus(false, `${action} group ${name}: ${e.message}`);
+  }
+}
+
 function renderEndpoints(endpoints) {
   const tbody = document.querySelector("#endpoint-table tbody");
   tbody.innerHTML = "";
@@ -245,28 +324,223 @@ function closeConfigPanel() {
   document.getElementById("config-overlay").hidden = true;
 }
 
+/* PR5 (#61): graceful-degrade settings panel.
+
+   The pre-PR1 layout was a single set of {max_inflight, min_interval,
+   exhaust_cooldown} inputs that mapped to flat `cfg.category.*` fields.
+   PR1 introduced per-category values under `cfg.category.limits.{cat}`
+   while keeping the flat fields as a legacy mirror, and PR4 added
+   `cfg.custom_groups.{name}`. The dashboard now:
+
+   * Reads the new shapes (renders one row per category, one card per
+     custom group) and drops the legacy flat input.
+   * Detects a pre-v2.11.0 worker by the absence of `cfg.category.limits`
+     and shows a `compat-banner` telling the user how to recover. The
+     rest of the dashboard (jobs / stats) keeps working — the banner
+     only suppresses the per-category form.
+   * Hits `/api/version` (worker shipped that endpoint in PR2) before
+     `/api/config` so the banner can quote the actual worker version
+     when it differs from this dashboard.
+*/
+
 async function loadConfig() {
+  let workerVersion = null;
   try {
-    const cfg = await fetchJSON("/api/config");
-    document.getElementById("cfg-max-inflight").value = cfg.category?.max_inflight ?? 1;
-    document.getElementById("cfg-min-interval").value = cfg.category?.min_interval ?? 1.0;
-    document.getElementById("cfg-cooldown").value = cfg.category?.exhaust_cooldown ?? 3600;
-    document.getElementById("cfg-max-concurrent").value = cfg.endpoint?.default_max_concurrent ?? 2;
-    document.getElementById("cfg-ep-interval").value = cfg.endpoint?.default_min_interval ?? 10.0;
-    document.getElementById("cfg-idle-timeout").value = cfg.worker?.idle_timeout ?? 60;
-    showConfigResult("", "");
+    const v = await fetchJSON("/api/version");
+    workerVersion = v.version;
+  } catch {
+    // /api/version is missing → almost certainly a pre-v2.11.0 worker.
+    // Leave workerVersion as null; the banner copy handles that case.
+  }
+
+  let cfg;
+  try {
+    cfg = await fetchJSON("/api/config");
   } catch (e) {
-    showConfigResult("Failed to load config: " + e.message, "error");
+    showCompatBanner(
+      "Failed to load /api/config from worker.\n" +
+      "  Reason: " + e.message + "\n" +
+      "  Is the worker running on " + (window.WORKER_URL || "127.0.0.1:54321") + "?",
+      "error",
+    );
+    return;
+  }
+
+  // Render endpoint defaults + worker settings unconditionally — these
+  // live outside the per-category schema and have not changed shape
+  // since lazy-v2.10.x.
+  document.getElementById("cfg-max-concurrent").value = cfg.endpoint?.default_max_concurrent ?? 2;
+  document.getElementById("cfg-ep-interval").value = cfg.endpoint?.default_min_interval ?? 10.0;
+  document.getElementById("cfg-idle-timeout").value = cfg.worker?.idle_timeout ?? 60;
+
+  // Worker version label in the header.
+  const verEl = document.getElementById("worker-version-info");
+  if (verEl) {
+    verEl.textContent = workerVersion
+      ? `Worker: ${workerVersion}`
+      : "Worker: (pre-v2.11.0)";
+  }
+
+  // PR5 fix #2: the headline test for "is this worker new enough" is
+  // the presence of `cfg.category.limits`. The pre-v2.11.0 shape was
+  // `cfg.category.{max_inflight,min_interval,exhaust_cooldown}` flat.
+  const limitsObj = cfg?.category?.limits;
+  const limitsObjValid = limitsObj && typeof limitsObj === "object" && !Array.isArray(limitsObj);
+  if (!limitsObjValid) {
+    showCompatBanner(
+      "Worker API appears to be pre-v2.11.\n" +
+      "This dashboard requires Worker v2.11.0 or later for per-category " +
+      "settings.\n" +
+      "Detected worker version: " + (workerVersion ?? "(unknown — /api/version missing)") + "\n" +
+      "Please upgrade or restart the worker:\n" +
+      "  curl -X POST http://127.0.0.1:54321/api/worker/shutdown\n" +
+      "then re-run a client command to spawn a fresh worker.",
+      "warn",
+    );
+    // Clear the per-category / per-group forms so we don't show stale
+    // values from an earlier load.
+    document.getElementById("cat-limits-grid").innerHTML = "";
+    document.getElementById("group-limits-grid").innerHTML = "";
+    return;
+  }
+
+  hideCompatBanner();
+  renderCategoryLimitsForm(limitsObj);
+  renderGroupLimitsForm(cfg.custom_groups || {});
+  showConfigResult("", "");
+}
+
+function showCompatBanner(message, level) {
+  const banner = document.getElementById("compat-banner");
+  if (!banner) return;
+  banner.textContent = message;
+  banner.className = "compat-banner compat-" + (level || "warn");
+  banner.hidden = false;
+}
+
+function hideCompatBanner() {
+  const banner = document.getElementById("compat-banner");
+  if (!banner) return;
+  banner.hidden = true;
+  banner.textContent = "";
+  banner.className = "compat-banner";
+}
+
+const _CAT_KEYS = ["max_inflight", "min_interval", "exhaust_cooldown"];
+
+function renderCategoryLimitsForm(limits) {
+  // limits = { t2i: { max_inflight, min_interval, exhaust_cooldown }, ... }
+  const grid = document.getElementById("cat-limits-grid");
+  grid.innerHTML = "";
+
+  // Header row (sorted category names — same order PR1 worker uses for
+  // the legacy mirror keys, so the user reads consistent ordering
+  // everywhere).
+  const cats = Object.keys(limits).sort();
+  if (cats.length === 0) {
+    grid.appendChild(el("div", { class: "empty-hint", text: "(no categories configured)" }));
+    return;
+  }
+
+  const header = el("div", { class: "cat-limits-grid-header" },
+    el("span", { text: "Category" }),
+    el("span", { text: "Max Inflight" }),
+    el("span", { text: "Min Interval (s)" }),
+    el("span", { text: "429 Cooldown (s)" }),
+  );
+  grid.appendChild(header);
+
+  for (const cat of cats) {
+    const vals = limits[cat] || {};
+    const row = el("div", { class: "cat-limits-row" });
+    row.appendChild(el("span", { class: "key-label", text: cat }));
+    for (const key of _CAT_KEYS) {
+      const input = el("input", {
+        type: "number",
+        min: key === "max_inflight" ? 1 : 0,
+        step: key === "min_interval" ? 0.1 : 1,
+      });
+      input.value = vals[key] ?? "";
+      input.dataset.cat = cat;
+      input.dataset.key = key;
+      row.appendChild(input);
+    }
+    grid.appendChild(row);
+  }
+}
+
+function renderGroupLimitsForm(groups) {
+  // groups = { name: { endpoints, max_inflight, min_interval, exhaust_cooldown } }
+  const grid = document.getElementById("group-limits-grid");
+  grid.innerHTML = "";
+
+  const names = Object.keys(groups);
+  if (names.length === 0) {
+    grid.appendChild(el("div", { class: "empty-hint", text: "(no custom groups configured)" }));
+    return;
+  }
+
+  const header = el("div", { class: "group-limits-grid-header" },
+    el("span", { text: "Group" }),
+    el("span", { text: "Max Inflight" }),
+    el("span", { text: "Min Interval (s)" }),
+    el("span", { text: "429 Cooldown (s)" }),
+  );
+  grid.appendChild(header);
+
+  for (const name of names) {
+    const vals = groups[name] || {};
+    const row = el("div", { class: "group-limits-row" });
+    row.appendChild(el("span", {
+      class: "key-label",
+      text: name,
+      title: Array.isArray(vals.endpoints) ? vals.endpoints.join("\n") : "",
+    }));
+    for (const key of _CAT_KEYS) {
+      const input = el("input", {
+        type: "number",
+        min: key === "max_inflight" ? 1 : 0,
+        step: key === "min_interval" ? 0.1 : 1,
+      });
+      input.value = vals[key] ?? "";
+      input.dataset.group = name;
+      input.dataset.key = key;
+      row.appendChild(input);
+    }
+    grid.appendChild(row);
   }
 }
 
 async function applyConfig() {
+  // Build per-category PATCH body from the rendered form. We only
+  // include fields the user actually changed (skip blank / invalid)
+  // so an unrelated category isn't accidentally clamped to 0.
+  const catLimits = {};
+  for (const input of document.querySelectorAll("#cat-limits-grid input")) {
+    const cat = input.dataset.cat;
+    const key = input.dataset.key;
+    if (!cat || !key) continue;
+    if (input.value === "") continue;
+    const num = Number(input.value);
+    if (!Number.isFinite(num)) continue;
+    if (!catLimits[cat]) catLimits[cat] = {};
+    catLimits[cat][key] = num;
+  }
+
+  // Same shape for custom_groups.
+  const grpLimits = {};
+  for (const input of document.querySelectorAll("#group-limits-grid input")) {
+    const grp = input.dataset.group;
+    const key = input.dataset.key;
+    if (!grp || !key) continue;
+    if (input.value === "") continue;
+    const num = Number(input.value);
+    if (!Number.isFinite(num)) continue;
+    if (!grpLimits[grp]) grpLimits[grp] = {};
+    grpLimits[grp][key] = num;
+  }
+
   const body = {
-    category: {
-      max_inflight: Number(document.getElementById("cfg-max-inflight").value),
-      min_interval: Number(document.getElementById("cfg-min-interval").value),
-      exhaust_cooldown: Number(document.getElementById("cfg-cooldown").value),
-    },
     endpoint: {
       default_max_concurrent: Number(document.getElementById("cfg-max-concurrent").value),
       default_min_interval: Number(document.getElementById("cfg-ep-interval").value),
@@ -275,6 +549,16 @@ async function applyConfig() {
       idle_timeout: Number(document.getElementById("cfg-idle-timeout").value),
     },
   };
+  // Only include category.limits / groups if the form actually had values
+  // for them — keeps the worker logs clean and avoids an empty
+  // `category.limits: {}` triggering a no-op apply.
+  if (Object.keys(catLimits).length > 0) {
+    body.category = { limits: catLimits };
+  }
+  if (Object.keys(grpLimits).length > 0) {
+    body.groups = grpLimits;
+  }
+
   try {
     const result = await fetchJSON("/api/config", {
       method: "PATCH",

--- a/.claude/skills/queue-dashboard/scripts/static/index.html
+++ b/.claude/skills/queue-dashboard/scripts/static/index.html
@@ -16,6 +16,7 @@
       <button id="btn-stop" class="wk-btn" hidden title="Stop worker">■ Stop</button>
       <button id="btn-restart" class="wk-btn" hidden title="Restart worker">↻ Restart</button>
     </div>
+    <span id="worker-version-info" class="worker-version" title="Worker version"></span>
     <span id="status-indicator" title="Connection status">●</span>
   </header>
 
@@ -27,11 +28,18 @@
       <h2>Settings</h2>
       <button id="panel-close" aria-label="Close">×</button>
     </div>
-    <fieldset>
-      <legend>Category Limits</legend>
-      <label>Max Inflight <input id="cfg-max-inflight" type="number" min="1" step="1"></label>
-      <label>Min Interval (s) <input id="cfg-min-interval" type="number" min="0" step="0.1"></label>
-      <label>429 Cooldown (s) <input id="cfg-cooldown" type="number" min="0" step="60"></label>
+
+    <!-- PR5 (#61) graceful-degrade banner: shown when the worker
+         predates lazy-v2.11 and `cfg.category.limits` is missing. -->
+    <div id="compat-banner" class="compat-banner" hidden></div>
+
+    <fieldset id="cat-limits-fieldset">
+      <legend>Category Limits (per-category)</legend>
+      <div id="cat-limits-grid"></div>
+    </fieldset>
+    <fieldset id="group-limits-fieldset">
+      <legend>Custom Groups</legend>
+      <div id="group-limits-grid"></div>
     </fieldset>
     <fieldset>
       <legend>Endpoint Defaults</legend>
@@ -57,9 +65,15 @@
     <div class="card"><h3>Failed</h3><div id="count-failed">-</div></div>
   </section>
 
-  <section id="categories">
-    <h2>Categories</h2>
-    <div id="category-grid"></div>
+  <section id="categories-and-groups">
+    <div id="categories">
+      <h2>Categories</h2>
+      <div id="category-grid"></div>
+    </div>
+    <div id="custom-groups">
+      <h2>Custom Groups</h2>
+      <div id="group-grid"></div>
+    </div>
   </section>
 
   <section id="skills">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@
   - **Bytedance Seedance v2.0 動画モデル群 (`t2v_sd2` / `i2v_sd2` / `r2v_sd2`) を初期同梱** (`generate_skill.py` テンプレート + `queue_config.example.json`)。URL prefix が標準カテゴリ list 外のため、未設定だと rate-limit accounting がスキップされる問題への安全策
   - 詳細: [docs/custom-groups.md](docs/custom-groups.md)
 - 新規テスト: `test_custom_group_limiter.py` (38 tests), `test_dispatcher_groups.py` (12 tests), `test_worker_groups.py` (16 tests), `test_generate_skill_queue.py` の Seedance pin (3 tests) — 構築 / glob / concurrent smoke / unknown handling / dispatcher routing isolation / HTTP API / template defaults をカバー
+- **Queue Dashboard: per-category UI + Custom Groups + graceful degrade + `--port 0`** (#61, #53):
+  - **Categories と Custom Groups の二段組レイアウト**: 左に t2i/i2i/t2v/i2v、右にユーザー定義グループ。900px 以下では縦積みに自動切替。グループカードは indigo 左ボーダーで識別性向上、マッチする endpoint パターンをカード内に inline 表示
+  - **Per-category Settings グリッド**: t2i/i2i/t2v/i2v 各行に `max_inflight` / `min_interval` / `429 cooldown` の入力欄。空欄 skip ロジックで「変えたいフィールドだけ送信」(`0` は有効値として通過)
+  - **Per-group Settings グリッド**: 各カスタムグループに 1 行ずつ。Group 名 tooltip でマッチ endpoint パターン確認
+  - **Worker version 表示** (PR2 連携): ヘッダーに `/api/version` 経由でバージョン表示。古い worker なら `(pre-v2.11.0)`
+  - **Compatibility banner (graceful degrade)** (PHASE1_PLAN_v3 fix #2): `cfg.category.limits` 不在を検出して Settings パネルに warning + 復旧手順 (`curl -X POST .../api/worker/shutdown`) 表示。jobs list / stats は引き続き動作
+  - **新 API endpoints の whitelist 追加**: `/api/version`, `/api/groups`, `POST /api/groups/{name}/{pause|resume}` (`{name}` は `[A-Za-z0-9_\-.]+` を許容)
+  - **`--port 0` 動的ポート割当** (#53): `--port 0` で OS が空きポートを選択、stdout に `PORT=NNNNN` 形式で実ポート出力。subprocess driver で grep parse 可能。54322 が他サービスと衝突する long-standing pain point の解消
+- 新規テスト: `test_dashboard_smoke.py` (7 tests) — `--port 0` の subprocess + `PORT=NNNNN` parse + 実 HTTP 疎通、proxy whitelist (`/api/version` / `/api/groups` / `POST /api/groups/{name}/{action}` / dotted group name / unauthorized POST blocked) をカバー。Windows 環境対応で `PYTHONIOENCODING=utf-8` を Popen に強制
 
 ### Changed (BREAKING)
 - **`set_max_inflight(cat, value)` の `cat` 引数必須化**: lazy-v2.10.x の単一引数 `set_max_inflight(value)` (全カテゴリ一括変更) は削除。`set_min_interval` / `set_exhaust_cooldown` も同様。worker の `PATCH /api/config` ハンドラが「全カテゴリ一括」の API レイヤを emulate する。
@@ -67,6 +76,8 @@
 - **lazy-v2.10.x worker と lazy-v2.11.0 client の組み合わせ**: 新クライアントは旧 worker から `X-Worker-Version` が返らないことを検知し、stderr に「pre-v2.11.0 worker の可能性、shutdown して再起動を」と 1 回警告します。処理は止めません (skew 中でも動く API パスがあるため)。**新版を上書きインストールする前に `curl -X POST http://127.0.0.1:54321/api/worker/shutdown` で古い worker を停止することを推奨** (詳細: [docs/version-handshake.md](docs/version-handshake.md))。
 - **`custom_groups` キーが無い既存 `queue_config.json`**: 完全互換。`custom_groups` は空 dict 扱いとなり、すべての endpoint がカテゴリ経由でルーティングされます (lazy-v2.10.x と同じ挙動)。新規インストールでは Seedance v2.0 動画モデル群 (`t2v_sd2` / `i2v_sd2` / `r2v_sd2`) が初期同梱されます — 既存ユーザーが Seedance v2.0 モデルを使う場合は `queue_config.json` に手動で追加するか、新規スキル生成 (`generate_skill.py`) を流すと反映されます。
 - **lazy-v2.10.x dashboard との組み合わせ**: dashboard は `custom_groups` セクションを表示しませんが、worker の HTTP API は引き続き動作します。`/api/config` の `custom_groups` フィールドは旧 dashboard には無視されるため、`category_rate_limits` の旧互換ミラーキーと同じく "ignore unknown fields" 戦略で安全に共存します。
+- **lazy-v2.11.0 dashboard と pre-v2.11 worker の組み合わせ**: 新 dashboard は `cfg.category.limits` 不在 + `/api/version` 404 を検出すると Settings パネルに **graceful degrade banner** を表示し、復旧手順 (`curl -X POST .../api/worker/shutdown`) を案内します。jobs list / stats / endpoint table は引き続き機能するので「ダッシュボードが完全に死ぬ」状態にはなりません。
+- **`--port 0` で実ポートを別プロセスから知りたい場合**: stdout の最初の出力が `PORT=NNNNN` 形式 (machine-parseable) になっています。`grep -oP 'PORT=\K\d+'` (bash) や `Select-String` (PowerShell) で取得できます。
 
 ## [lazy-v2.10.0](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/releases/tag/lazy-v2.10.0) (2026-04-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
 
 ### Compatibility
 - **lazy-v2.10.x の queue_config.json (旧 flat schema) は引き続き動作**します (起動時に `[CategoryLimiter] (instance ...) DEPRECATED: ...` 警告ログが 1 回出力)
-- **lazy-v2.10.x dashboard は引き続き動作**します (`GET /api/config` の旧互換ミラーキーで UI 値が空にならない)。ただし旧 dashboard から値編集すると **新 worker は全カテゴリに一括適用** します。per-category 編集には `lazy-v2.12.0` 以降の dashboard が必要。
+- **lazy-v2.10.x dashboard は引き続き動作**します (`GET /api/config` の旧互換ミラーキーで UI 値が空にならない)。ただし旧 dashboard から値編集すると **新 worker は全カテゴリに一括適用** します。per-category 編集には `lazy-v2.11.0` 以降の dashboard (本リリース同梱) が必要。
 - **lazy-v2.10.x worker と lazy-v2.11.0 client の組み合わせ**: 新クライアントは旧 worker から `X-Worker-Version` が返らないことを検知し、stderr に「pre-v2.11.0 worker の可能性、shutdown して再起動を」と 1 回警告します。処理は止めません (skew 中でも動く API パスがあるため)。**新版を上書きインストールする前に `curl -X POST http://127.0.0.1:54321/api/worker/shutdown` で古い worker を停止することを推奨** (詳細: [docs/version-handshake.md](docs/version-handshake.md))。
 - **`custom_groups` キーが無い既存 `queue_config.json`**: 完全互換。`custom_groups` は空 dict 扱いとなり、すべての endpoint がカテゴリ経由でルーティングされます (lazy-v2.10.x と同じ挙動)。新規インストールでは Seedance v2.0 動画モデル群 (`t2v_sd2` / `i2v_sd2` / `r2v_sd2`) が初期同梱されます — 既存ユーザーが Seedance v2.0 モデルを使う場合は `queue_config.json` に手動で追加するか、新規スキル生成 (`generate_skill.py`) を流すと反映されます。
 - **lazy-v2.10.x dashboard との組み合わせ**: dashboard は `custom_groups` セクションを表示しませんが、worker の HTTP API は引き続き動作します。`/api/config` の `custom_groups` フィールドは旧 dashboard には無視されるため、`category_rate_limits` の旧互換ミラーキーと同じく "ignore unknown fields" 戦略で安全に共存します。

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Claude Code用のMCPスキルジェネレーター。非同期ジョブパター
 | **DB スキーマ migration 基盤** | `PRAGMA user_version` ベースの簡易マイグレーション。Phase 1 では足場のみ追加 (実カラム変更は将来 migration で対応) | 自動 | [📖](docs/db-migration.md) |
 | **セッション管理** | MCPセッションをendpoint単位でキャッシュ。認証サーバーへの負荷を削減 | 自動 | |
 | **カテゴリpause/resume** | カテゴリ単位での手動一時停止・再開。他端末との枠共有時に便利 | `--pause-category` | |
-| **Queue Dashboard** | ブラウザから見えるキュー可視化Web UI。サマリー/カテゴリ/ジョブ一覧/失敗詳細/pause-resume。追加依存なし（Python stdlib + Vanilla JS） | 独立スキル | |
+| **Queue Dashboard** | ブラウザから見えるキュー可視化Web UI。サマリー/カテゴリ/Custom Groups/ジョブ一覧/失敗詳細/pause-resume、per-category & per-group 設定編集、worker version 表示、graceful degrade banner、`--port 0` 動的ポート割当。追加依存なし（Python stdlib + Vanilla JS） | 独立スキル | |
 
 ### ⚠️ 実行ディレクトリについて
 
@@ -715,10 +715,20 @@ python .claude/skills/queue-dashboard/scripts/queue_dashboard.py
 **オプション:**
 | オプション | デフォルト | 説明 |
 |-----------|-----------|------|
-| `--port` | 54322 | ダッシュボードのHTTPポート |
+| `--port` | 54322 | ダッシュボードのHTTPポート。**`--port 0` で OS が空きポートを自動割当** (default の 54322 が他サービスと衝突する場合)。実ポートは stdout に `PORT=NNNNN` 形式で出力されるので subprocess で parse 可能 |
 | `--worker-url` | `http://127.0.0.1:54321` | ワーカーAPIのベースURL |
 | `--no-open` | false | ブラウザの自動オープンを抑制 |
 | `--host` | 127.0.0.1 | バインドアドレス |
+
+**`--port 0` の出力例:**
+```
+$ python .claude/skills/queue-dashboard/scripts/queue_dashboard.py --port 0 --no-open
+PORT=49152
+[Queue Dashboard] http://127.0.0.1:49152/
+[Queue Dashboard] Worker API: http://127.0.0.1:54321
+[Queue Dashboard] Project root: ...
+  Ctrl+C to stop
+```
 
 ### 画面構成
 
@@ -726,12 +736,22 @@ python .claude/skills/queue-dashboard/scripts/queue_dashboard.py
 - **Pending / Running / Completed / Failed** の合計件数をリアルタイム表示
 - 2秒ごとに自動更新（タブ非表示時は間引き、エラー時は指数バックオフ）
 
-#### カテゴリ別状態
-- t2i / i2i / t2v / i2v の各カテゴリの状態をカード表示
-- **Inflight**: 現在の同時実行数 / 上限
-- **Cooldown**: 429受信後の残りcooldown秒数
-- **Consecutive 429**: 連続429回数（情報表示のみ）
-- **Pause / Resume ボタン**: カテゴリの手動一時停止・再開
+#### カテゴリ別状態 + Custom Groups (二段組)
+**lazy-v2.11.0+** ではカテゴリと Custom Groups が左右に並ぶ二段組レイアウト（900px 以下では縦積み）。
+
+- **Categories** (左): t2i / i2i / t2v / i2v の各カテゴリの状態をカード表示
+  - **Inflight**: 現在の同時実行数 / 上限
+  - **Cooldown**: 429受信後の残りcooldown秒数
+  - **Consecutive 429**: 連続429回数（情報表示のみ）
+  - **Pause / Resume ボタン**: カテゴリの手動一時停止・再開
+- **Custom Groups** (右、lazy-v2.11.0+): `queue_config.json` で定義したグループの状態をカード表示
+  - インディゴの左ボーダーで Categories と区別
+  - **マッチする endpoint パターン** をカード内に表示 (どの URL がそのグループに gating されるかが一目で分かる)
+  - 同じく Inflight / Cooldown / 429 / Pause / Resume
+  - 同梱の Bytedance Seedance v2.0 デフォルト (`t2v_sd2` / `i2v_sd2` / `r2v_sd2`) もここに表示
+
+#### Worker version 表示 (lazy-v2.11.0+)
+ヘッダー右側に worker のバージョン (`/api/version` 経由) を表示。古い worker (pre-v2.11.0) を踏んだ場合は `(pre-v2.11.0)` と表示し、Settings パネルに **graceful degrade banner** で復旧手順 (`curl -X POST .../api/worker/shutdown`) を案内します。jobs list と stats は引き続き機能します。
 
 #### 登録済みスキル一覧
 - `.claude/skills/` と `.agents/skills/` のスキルを自動走査
@@ -749,20 +769,25 @@ python .claude/skills/queue-dashboard/scripts/queue_dashboard.py
 
 ### 設定パネル（☰ ハンバーガーメニュー）
 
-ヘッダー左の ☰ ボタンから、キューシステムの設定をリアルタイムに変更できます。
+ヘッダー左の ☰ ボタンから、キューシステムの設定をリアルタイムに変更できます。**lazy-v2.11.0+** では per-category と per-group の独立編集に対応。
 
+#### Category Limits グリッド (lazy-v2.11.0+)
+カテゴリ (t2i / i2i / t2v / i2v) ごとに 1 行、それぞれ `Max Inflight` / `Min Interval (s)` / `429 Cooldown (s)` の入力欄。空欄のまま Apply すると **そのフィールドだけ送信されない** ので、特定の値だけ変えたいときに便利 (`0` は有効値として送信)。
+
+#### Custom Groups Limits グリッド (lazy-v2.11.0+)
+`queue_config.json` で定義した各グループに 1 行ずつ。Group 名にカーソルを乗せると tooltip でマッチ対象 endpoint パターンを確認できます。
+
+#### その他の設定
 | 設定 | デフォルト | 説明 |
 |------|-----------|------|
-| **Max Inflight** | 1 | カテゴリあたりの同時submit数 |
-| **Min Interval (s)** | 1.0 | カテゴリ内submit間の最小待ち時間 |
-| **429 Cooldown (s)** | 3600 | 429受信後のcooldown秒数 |
-| **Max Concurrent** | 2 | エンドポイントあたりの同時ジョブ数 |
-| **EP Min Interval (s)** | 10.0 | エンドポイント内のdispatch間隔 |
-| **Idle Timeout (s)** | 60 | ワーカー自動停止までの秒数 |
+| **Endpoint Defaults: Max Concurrent** | 2 | エンドポイントあたりの同時ジョブ数 (per-endpoint 個別 override がない場合のデフォルト) |
+| **Endpoint Defaults: Min Interval (s)** | 10.0 | エンドポイント内の dispatch 間隔のデフォルト |
+| **Worker: Idle Timeout (s)** | 60 | ワーカー自動停止までの秒数 |
 
 - **Apply**: 変更を即座にワーカーに反映（再起動不要）
 - **Reload Current**: ワーカーから現在の設定値を再読み込み
 - 変更結果は Applied / Rejected / Requires Restart に分けて表示
+- **Compatibility banner** (lazy-v2.11.0+): worker が古い (`/api/config` に `category.limits` が無い) 場合、per-category/per-group 編集グリッドの代わりに復旧手順を案内するバナーを表示
 
 ### ワーカー管理ボタン
 

--- a/docs/category-limits.md
+++ b/docs/category-limits.md
@@ -118,7 +118,7 @@ curl -X PATCH http://127.0.0.1:54321/api/config \
 }
 ```
 
-> **Warning**: 旧 `lazy-v2.10.x dashboard` から値編集 PATCH を投げると、新 worker は **全カテゴリに一括適用** します。最初のカテゴリの値だけを変えたつもりが全カテゴリに展開されるので注意してください。**per-category の独立編集を行うには `lazy-v2.12.0` 以降の dashboard が必要** です。
+> **Warning**: 旧 `lazy-v2.10.x dashboard` から値編集 PATCH を投げると、新 worker は **全カテゴリに一括適用** します。最初のカテゴリの値だけを変えたつもりが全カテゴリに展開されるので注意してください。**per-category の独立編集を行うには `lazy-v2.11.0` 以降の dashboard (本リリース同梱) が必要** です。
 
 ### 入力検証
 


### PR DESCRIPTION
## Summary

Closes #61 and #53 (Phase 1 PR5, final PR for the integrated lazy-v2.11.0 release).

**Status: draft** — implementation + tests are landed; docs / CHANGELOG / README updates are coming as a follow-up commit on this same branch.

Surfaces the per-category and per-group state PR1/PR4 added in the dashboard UI, gives users a clear path out of the dashboard-vs-worker version mismatch they would otherwise hit silently, and rounds out the long-standing port-collision pain point with --port 0 dynamic allocation.

## What changes

### `queue_dashboard.py`

- **`--port 0` (#53)**: lets the OS pick a free TCP port. The actual port is printed on stdout as a machine-parseable `PORT=NNNNN` line followed by the human-readable banner. Closes #53.
- **Whitelist additions for PR2 + PR4**: `/api/version`, `/api/groups`, `POST /api/groups/{name}/{pause|resume}`. The `{name}` regex accepts ` [A-Za-z0-9_\-.]+ ` rather than a closed enum because group names are user-defined config — bogus names reach the user as the worker's 404 + `available_groups` body, which is the more useful failure mode.
- `sys.stdout.flush()` after the startup banner so subprocess drivers reading line-by-line don't hang.

### `static/index.html`

- New `#categories-and-groups` two-column section: Categories left, Custom Groups right. Stacks to one column under 900px viewport.
- Settings panel: per-category limits grid + Custom Groups limits grid + compat banner. The pre-PR1 single trio of inputs is replaced.
- Header: `#worker-version-info` shows whatever `/api/version` returned, or `(pre-v2.11.0)`.

### `static/dashboard.css`

- Grid layout for `#categories-and-groups` + responsive breakpoint.
- `.group-card` styled with an indigo left border (paused → amber) so users can tell at a glance which limiter is gating a job.
- `.cat-limits-row` / `.group-limits-row` for the per-key inputs in the panel.
- `.compat-banner` warn / error variants. `.worker-version` header label.

### `static/dashboard.js`

- `refresh()` reads `stats.custom_groups` and renders via the new `renderCustomGroups`.
- `renderCustomGroups` mirrors `renderCategories`'s shape (inflight / cooldown / consec 429 / pause/resume) and shows the matched endpoint patterns inline.
- **`loadConfig()` graceful degrade (PHASE1_PLAN_v3 fix #2)**:
  - Hits `/api/version` first (catches a missing endpoint as pre-v2.11.0 worker).
  - Reads `cfg.category.limits` (PR1 schema). Missing → compat banner explaining how to recover via `curl -X POST .../api/worker/shutdown`. The rest of the dashboard keeps working.
  - Renders per-category and per-group input grids.
- `applyConfig()` builds a PATCH body of the new shape:
  ```json
  {
    \"category\": {\"limits\": {\"t2v\": {\"max_inflight\": 1}}},
    \"groups\": {\"premium-video\": {\"max_inflight\": 2}}
  }
  ```
  Skips inputs left blank so an unrelated category isn't accidentally clamped.

## Verification

```
\$ pytest .claude/skills/mcp-async-skill/scripts/tests/ -q
415 passed in ~79s
```

Counts:
- baseline (post-PR4 main): 408
- this PR adds: +7 (`test_dashboard_smoke.py`)
- final: 415

### Test coverage highlights

- **TestPortZeroAllocation** — spawns the dashboard with `--port 0 --no-open`, parses the `PORT=NNNNN` line out of stdout, sanity-checks the port and serves `/api/health`. Pinned because a regression that dropped the `PORT=` line would silently strand any subprocess driver.
- **TestProxyWhitelist** — 6 tests covering `/api/version`, `/api/groups`, `POST /api/groups/{name}/{pause|resume}`, dotted group names, and "out-of-whitelist POST never reaches the worker". Each uses an in-process mock worker to confirm the dashboard actually forwards rather than 404-ing locally.

Subprocess on Windows: `PYTHONIOENCODING=utf-8` + `encoding=\"utf-8\"` forced on `Popen` because the repo lives under a path with Japanese characters on the developer's Windows checkout. Without this, the cp932 default codec dies on the very first stdout read.

## Test plan

- [x] `pytest .claude/skills/mcp-async-skill/scripts/tests/ -q` → 415 passed
- [x] `--port 0` produces `PORT=NNNNN` on stdout, the dashboard binds and serves
- [x] Whitelist forwards new endpoints (verified via mock worker)
- [ ] **Docs follow-up commit** (planned on this branch before un-drafting): SKILL.md updates for queue-dashboard, README feature row, CHANGELOG `[Unreleased]` entry
- [ ] **Manual**: open the dashboard against a fresh `lazy-v2.11.0` worker, confirm Categories + Custom Groups sections both render, the Seedance v2.0 default groups appear, the Settings panel renders per-category and per-group input grids
- [ ] **Manual (graceful degrade)**: point the dashboard at a `lazy-v2.10.x` worker (e.g. via `--worker-url http://127.0.0.1:54399` to a separately-launched old worker) — confirm the compat banner appears in Settings, jobs list keeps working, header shows `(pre-v2.11.0)`
- [ ] **Manual (--port 0)**: run `python queue_dashboard.py --port 0 --no-open`, confirm `PORT=NNNNN` is printed and the URL is reachable

## Out of scope

- Bulk group editing, group create/delete from the UI — `queue_config.json` remains the source of truth for adding/removing groups.
- Dashboard-side X-Worker-Version mismatch warnings (PR2 already does this on the CLI; the dashboard reads it for display only).

## Reviewing this PR

Suggested commit-by-commit reading order:

1. `5f36440` feat: dashboard core (`queue_dashboard.py` whitelist + --port 0, HTML two-column layout + Settings panel rewrite, CSS for groups/banner, JS `loadConfig` rewrite + `renderCustomGroups`)
2. `6129f3e` test: 7 subprocess smoke tests covering --port 0 PORT=NNNNN parsing and proxy whitelist for /api/version + /api/groups + group pause/resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)