### PR TITLE
fix(queue): promote r2v to an independent category (lazy-v2.11.1)

### DIFF
--- a/.claude/skills/mcp-async-skill/scripts/generate_skill.py
+++ b/.claude/skills/mcp-async-skill/scripts/generate_skill.py
@@ -983,10 +983,11 @@ def detect_id_param_name(tools: list[dict]) -> str:
 def generate_queue_config(endpoint: str) -> dict:
     """Generate a default queue_config.json for the given endpoint.
 
-    Uses the lazy-v2.11.0 per-category schema: each of t2i/i2i/t2v/i2v has
-    its own ``max_inflight``, ``min_interval``, and ``exhaust_cooldown``.
+    Uses the lazy-v2.11.0+ per-category schema: each of t2i/i2i/t2v/i2v/r2v
+    has its own ``max_inflight``, ``min_interval``, and ``exhaust_cooldown``.
     Adjust these per category to match the upstream service's per-category
-    rate limits.
+    rate limits. ``r2v`` is tracked independently because the upstream MCP
+    service applies r2v rate limits separately from i2v (lazy-v2.11.1+).
     """
     per_cat_default = {
         "max_inflight": 1,
@@ -1008,13 +1009,14 @@ def generate_queue_config(endpoint: str) -> dict:
             }
         },
         "category_rate_limits": {
-            "categories": ["t2i", "i2i", "t2v", "i2v"],
-            "aliases": {"r2i": "i2i", "r2v": "i2v"},
+            "categories": ["t2i", "i2i", "t2v", "i2v", "r2v"],
+            "aliases": {"r2i": "i2i"},
             "limits": {
                 "t2i": dict(per_cat_default),
                 "i2i": dict(per_cat_default),
                 "t2v": dict(per_cat_default),
                 "i2v": dict(per_cat_default),
+                "r2v": dict(per_cat_default),
             },
         },
         # PR4 (#60): user-defined endpoint groups with their own

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/category_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/category_limiter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Category-level rate limiting for MCP job queue.
 
-Manages per-category (t2i, i2i, t2v, i2v) dispatch gating with
+Manages per-category (t2i, i2i, t2v, i2v, r2v) dispatch gating with
 **per-category individual values** for inflight, min_interval, and
 429 cooldown:
 
@@ -39,9 +39,16 @@ from .limiter_state import LimiterStateMixin
 
 logger = logging.getLogger(__name__)
 
-KNOWN_CATEGORIES: set[str] = {"t2i", "i2i", "t2v", "i2v"}
+KNOWN_CATEGORIES: set[str] = {"t2i", "i2i", "t2v", "i2v", "r2v"}
 
-DEFAULT_ALIASES: dict[str, str] = {"r2i": "i2i", "r2v": "i2v"}
+DEFAULT_ALIASES: dict[str, str] = {"r2i": "i2i"}
+
+# Aliases that are forbidden at runtime regardless of user config.
+# `r2v` was historically aliased to `i2v`, but the upstream MCP service
+# now applies r2v rate limits independently from i2v, so collapsing the
+# two would cause spurious 429s on the i2v side. We strip any
+# `aliases.r2v` entry from user-provided config and warn once.
+FORBIDDEN_ALIASES: frozenset[str] = frozenset({"r2v"})
 
 # Hardcoded fallback values for categories / keys missing from `limits`.
 # The canonical schema is to fully populate `limits.{cat}.{key}` for each
@@ -79,10 +86,24 @@ class CategoryLimiter(LimiterStateMixin):
                 set(limits_block.keys()) if limits_block else set(KNOWN_CATEGORIES)
             )
 
+        user_aliases = dict(config.get("aliases", {}))
+        dropped_forbidden = [k for k in user_aliases if k in FORBIDDEN_ALIASES]
+        for k in dropped_forbidden:
+            user_aliases.pop(k, None)
         self._aliases: dict[str, str] = {
             **DEFAULT_ALIASES,
-            **config.get("aliases", {}),
+            **user_aliases,
         }
+        if dropped_forbidden:
+            logger.warning(
+                "[CategoryLimiter] (instance %s) ignored forbidden alias keys "
+                "in config (`aliases.%s`): these endpoint prefixes now have "
+                "independent server-side rate limits and must be tracked as "
+                "their own categories. Update `queue_config.json` to remove "
+                "the alias entry. See docs/category-limits.md.",
+                id(self),
+                ", aliases.".join(dropped_forbidden),
+            )
 
         # ---- Per-category limits (dict) ----
         self._max_inflight: dict[str, int] = {}

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/custom_group_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/custom_group_limiter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """User-defined custom-group rate limiting (PR4 / #60).
 
-Categories (``t2i`` / ``i2i`` / ``t2v`` / ``i2v``) cover the common
+Categories (``t2i`` / ``i2i`` / ``t2v`` / ``i2v`` / ``r2v``) cover the common
 case but cannot express "throttle these specific endpoints together
 regardless of category". The upstream MCP service applies extra,
 narrower rate limits to certain high-cost models (e.g. video models

--- a/.claude/skills/mcp-async-skill/scripts/mcp_async_call.py
+++ b/.claude/skills/mcp-async-skill/scripts/mcp_async_call.py
@@ -1311,7 +1311,7 @@ Examples:
     queue_group.add_argument("--show-args", action="store_true",
                              help="Include original submit args in --list / --wait responses")
     queue_group.add_argument("--pause-category", metavar="CATEGORY",
-                             help="Pause a category (t2i, i2i, t2v, i2v)")
+                             help="Pause a category (t2i, i2i, t2v, i2v, r2v)")
     queue_group.add_argument("--resume-category", metavar="CATEGORY",
                              help="Resume a paused category")
 

--- a/.claude/skills/mcp-async-skill/scripts/queue_config.example.json
+++ b/.claude/skills/mcp-async-skill/scripts/queue_config.example.json
@@ -17,13 +17,14 @@
     }
   },
   "category_rate_limits": {
-    "categories": ["t2i", "i2i", "t2v", "i2v"],
-    "aliases": {"r2i": "i2i", "r2v": "i2v"},
+    "categories": ["t2i", "i2i", "t2v", "i2v", "r2v"],
+    "aliases": {"r2i": "i2i"},
     "limits": {
       "t2i": {"max_inflight": 3, "min_interval": 1.0, "exhaust_cooldown": 600},
       "i2i": {"max_inflight": 2, "min_interval": 1.0, "exhaust_cooldown": 3600},
       "t2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 1800},
-      "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
+      "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600},
+      "r2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
     }
   },
   "custom_groups": {

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_category_limiter.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_category_limiter.py
@@ -34,6 +34,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from job_queue.category_limiter import (  # noqa: E402
     CategoryLimiter,
+    DEFAULT_ALIASES,
+    FORBIDDEN_ALIASES,
     HARDCODED_DEFAULT_EXHAUST_COOLDOWN,
     HARDCODED_DEFAULT_MAX_INFLIGHT,
     HARDCODED_DEFAULT_MIN_INTERVAL,
@@ -51,6 +53,7 @@ def _make_limiter(**overrides) -> CategoryLimiter:
         "i2i": {"max_inflight": 2, "min_interval": 0.0, "exhaust_cooldown": 120},
         "t2v": {"max_inflight": 1, "min_interval": 0.0, "exhaust_cooldown": 1800},
         "i2v": {"max_inflight": 1, "min_interval": 0.0, "exhaust_cooldown": 3600},
+        "r2v": {"max_inflight": 1, "min_interval": 0.0, "exhaust_cooldown": 3600},
     }
     for cat, vals in overrides.items():
         base_limits.setdefault(cat, {}).update(vals)
@@ -364,10 +367,12 @@ class TestPublicCategoryAPI(unittest.TestCase):
     def test_get_categories_returns_sorted_deterministic(self):
         lim = _make_limiter()
         cats = lim.get_categories()
-        self.assertEqual(cats, ["i2i", "i2v", "t2i", "t2v"])
+        self.assertEqual(cats, ["i2i", "i2v", "r2v", "t2i", "t2v"])
         # Mutating the returned list must not affect internal state
         cats.append("foo")
-        self.assertEqual(lim.get_categories(), ["i2i", "i2v", "t2i", "t2v"])
+        self.assertEqual(
+            lim.get_categories(), ["i2i", "i2v", "r2v", "t2i", "t2v"],
+        )
 
 
 class TestSetterCategoryRequired(unittest.TestCase):
@@ -403,11 +408,57 @@ class TestSetterCategoryRequired(unittest.TestCase):
         self.assertNotIn("foobar", lim._max_inflight)
 
 
+class TestForbiddenAliases(unittest.TestCase):
+    """lazy-v2.11.1: ``r2v`` was historically aliased to ``i2v`` but is now
+    rate-limited independently by the upstream MCP service. We strip any
+    ``aliases.r2v`` entry from user-provided config and emit a warning
+    so old configs do not silently collapse the two categories."""
+
+    def test_forbidden_aliases_set_contains_r2v(self):
+        self.assertIn("r2v", FORBIDDEN_ALIASES)
+
+    def test_default_aliases_do_not_alias_r2v(self):
+        self.assertNotIn("r2v", DEFAULT_ALIASES)
+        # r2i is still aliased; that intent is unchanged.
+        self.assertEqual(DEFAULT_ALIASES.get("r2i"), "i2i")
+
+    def test_user_supplied_r2v_alias_is_silently_dropped(self):
+        """User config may still carry the legacy ``aliases.r2v`` key —
+        the limiter strips it so r2v URLs get accounted as r2v."""
+        with self.assertLogs("job_queue.category_limiter", level="WARNING") as cm:
+            lim = CategoryLimiter({
+                "categories": ["t2i", "i2i", "t2v", "i2v", "r2v"],
+                "aliases": {"r2v": "i2v", "r2i": "i2i"},
+                "limits": {
+                    cat: {"max_inflight": 1, "min_interval": 0.0,
+                          "exhaust_cooldown": 60}
+                    for cat in ("t2i", "i2i", "t2v", "i2v", "r2v")
+                },
+            })
+        # r2v URL routes to r2v, not i2v
+        self.assertEqual(
+            lim.extract_category("https://kamui-code.ai/r2v/fal/refer-video"),
+            "r2v",
+        )
+        # r2i alias survives untouched
+        self.assertEqual(
+            lim.extract_category("https://kamui-code.ai/r2i/fal/refer"),
+            "i2i",
+        )
+        # Warning fired and mentions the dropped key
+        self.assertTrue(
+            any("aliases.r2v" in msg for msg in cm.output),
+            f"expected warning to mention aliases.r2v; got {cm.output!r}",
+        )
+
+
 class TestKnownCategoriesConstant(unittest.TestCase):
     """Sanity check on the module-level KNOWN_CATEGORIES constant."""
 
-    def test_known_categories_contains_t2i_i2i_t2v_i2v(self):
-        self.assertEqual(KNOWN_CATEGORIES, {"t2i", "i2i", "t2v", "i2v"})
+    def test_known_categories_contains_t2i_i2i_t2v_i2v_r2v(self):
+        self.assertEqual(
+            KNOWN_CATEGORIES, {"t2i", "i2i", "t2v", "i2v", "r2v"},
+        )
 
     def test_default_categories_when_no_config_given(self):
         """A bare ``CategoryLimiter()`` falls back to KNOWN_CATEGORIES."""
@@ -417,7 +468,9 @@ class TestKnownCategoriesConstant(unittest.TestCase):
 
 class TestExtractCategory(unittest.TestCase):
     """``extract_category`` derives the canonical category from an MCP
-    endpoint URL, applying alias resolution (r2i → i2i, r2v → i2v)."""
+    endpoint URL. ``r2i`` is still aliased to ``i2i``; ``r2v`` is now
+    its own category (lazy-v2.11.1+) because the upstream MCP service
+    rate-limits it independently from i2v."""
 
     def test_extracts_t2i(self):
         lim = _make_limiter()
@@ -440,11 +493,16 @@ class TestExtractCategory(unittest.TestCase):
             "i2i",
         )
 
-    def test_aliases_r2v_to_i2v(self):
+    def test_extracts_r2v_as_independent_category(self):
+        """lazy-v2.11.1: r2v is no longer an alias of i2v.
+
+        Upstream MCP rate-limits r2v separately from i2v, so collapsing
+        the two would cause spurious 429s on the i2v side.
+        """
         lim = _make_limiter()
         self.assertEqual(
             lim.extract_category("https://kamui-code.ai/r2v/fal/refer-video"),
-            "i2v",
+            "r2v",
         )
 
     def test_unknown_path_returns_none(self):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [lazy-v2.11.1](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/releases/tag/lazy-v2.11.1) (2026-05-10)
+
+### Fixed
+- **`r2v` (reference-to-video) を独立カテゴリ化**: `r2v` は当初 `i2v` への alias として実装されていましたが、アップストリーム MCP サービスが `r2v` を `i2v` と独立にレートリミットしていることが確認されたため、独立カテゴリとして扱うよう修正しました。alias のままだと `r2v` ジョブが `i2v` 枠を消費し、`i2v` 側で予期しない 429 を誘発する可能性がありました。
+  - `KNOWN_CATEGORIES` に `r2v` を追加 (`{t2i, i2i, t2v, i2v, r2v}`)
+  - `DEFAULT_ALIASES` から `r2v` を削除 (`{r2i: i2i}` のみ残存)
+  - **`FORBIDDEN_ALIASES` 機構**: ユーザー `queue_config.json` に `aliases.r2v` が残っていても、起動時に **強制的に削除** + 警告ログを 1 回出力。利用者の queue_config.json を直接書き換える必要なく、自動で正しい挙動になります。
+  - `generate_skill.py` / `queue_config.example.json` の初期同梱 categories に `r2v` を追加 (`limits.r2v: {max_inflight: 1, min_interval: 1.0, exhaust_cooldown: 3600}`)
+  - `mcp_async_call.py --pause-category` の help を `(t2i, i2i, t2v, i2v, r2v)` に更新
+  - 詳細: [docs/category-limits.md](docs/category-limits.md) 「`r2v` の取り扱い (lazy-v2.11.1+)」
+
+### Compatibility
+- **lazy-v2.10.x / lazy-v2.11.0 の `queue_config.json` (`aliases: {"r2i": "i2i", "r2v": "i2v"}`) はそのまま動作します**。起動時に `[CategoryLimiter] (instance ...) ignored forbidden alias keys in config (\`aliases.r2v\`)` 警告が 1 回出力され、`r2v` URL は `r2v` 独立カテゴリとして集計されるようになります。
+- 既存利用者は `queue_config.json` の `aliases` から `r2v` を削除し、`limits.r2v` を追加することを推奨します (動作は自動で正しくなりますが、設定ファイルが意図と一致するほうが望ましい)。
+- **`r2i` (reference-to-image) は引き続き `i2i` の alias** として扱われます。`r2i` のアップストリーム独立レートリミットの有無は未確認のため、保守的にこの仕様を維持します。確定情報が入り次第、別 PR で対応予定です。
+
+### Tests
+- 新規テスト: `test_category_limiter.py` の `TestForbiddenAliases` クラス (3 tests) — `FORBIDDEN_ALIASES` 定数 / `DEFAULT_ALIASES` から r2v 除外 / ユーザー `aliases.r2v` の silent drop + 警告発火を検証
+- 更新テスト: `test_extracts_r2v_as_independent_category` (旧 `test_aliases_r2v_to_i2v` を置き換え) / `TestKnownCategoriesConstant` を r2v 含む 5 カテゴリに更新 / `TestPublicCategoryAPI.test_get_categories_returns_sorted_deterministic` を 5 カテゴリ並び順に更新
+- 全 `scripts/tests/` で 418 tests pass (lazy-v2.11.0 から +3)
+
 ## [lazy-v2.11.0](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/releases/tag/lazy-v2.11.0) (2026-05-10)
 
 ### Added

--- a/docs/category-limits.md
+++ b/docs/category-limits.md
@@ -1,6 +1,8 @@
 # Per-Category Rate Limits
 
-`lazy-v2.11.0` 以降、カテゴリ (`t2i` / `i2i` / `t2v` / `i2v`) ごとに inflight・min_interval・429 cooldown を **独立した値で設定可能**になりました。アップストリーム MCP サービス側もカテゴリごとにローリング窓レートリミットを分けて運用しているため、クライアント側でも対応する個別値を設定できます。
+`lazy-v2.11.0` 以降、カテゴリ (`t2i` / `i2i` / `t2v` / `i2v` / `r2v`) ごとに inflight・min_interval・429 cooldown を **独立した値で設定可能**になりました。アップストリーム MCP サービス側もカテゴリごとにローリング窓レートリミットを分けて運用しているため、クライアント側でも対応する個別値を設定できます。
+
+> **`r2v` の独立化** (`lazy-v2.11.1+`): 当初 `r2v` は `i2v` の alias として実装されていましたが、アップストリーム MCP サービスが `r2v` を `i2v` と独立にレートリミットしていることが確認されたため、`r2v` を独立カテゴリとして扱うようになりました。旧 `queue_config.json` に `aliases.r2v` 設定が残っていても、起動時に自動で無視され警告ログが 1 回出力されます (詳細は本ページ末尾の「`r2v` の取り扱い」を参照)。
 
 ## 設定スキーマ (`queue_config.json`)
 
@@ -9,13 +11,14 @@
 ```json
 {
   "category_rate_limits": {
-    "categories": ["t2i", "i2i", "t2v", "i2v"],
-    "aliases": {"r2i": "i2i", "r2v": "i2v"},
+    "categories": ["t2i", "i2i", "t2v", "i2v", "r2v"],
+    "aliases": {"r2i": "i2i"},
     "limits": {
       "t2i": {"max_inflight": 3, "min_interval": 1.0, "exhaust_cooldown": 600},
       "i2i": {"max_inflight": 2, "min_interval": 1.0, "exhaust_cooldown": 3600},
       "t2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 1800},
-      "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
+      "i2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600},
+      "r2v": {"max_inflight": 1, "min_interval": 1.0, "exhaust_cooldown": 3600}
     }
   }
 }
@@ -46,9 +49,21 @@
 旧形式の値は **すべての設定済みカテゴリに同じ値で展開** されます。worker 起動時に `[CategoryLimiter] (instance ...) DEPRECATED: ...` という警告ログが 1 回出力されます。
 旧形式は `lazy-v2.13.0 以降で削除予定` です。新規インストールでは新形式を使用してください。
 
+> 旧形式の例で `aliases.r2v` が含まれている場合、`lazy-v2.11.1+` ではこの alias 設定は **強制的に削除** され、`r2v` URL は r2v カテゴリとして独立に集計されます (詳細は本ページ末尾の「`r2v` の取り扱い」を参照)。
+
 ### Fallback 挙動
 
-設定漏れに対する保険として、`limits.{cat}` または個別キーが欠けている場合はモジュールレベルのハードコード初期値 (`max_inflight=1`, `min_interval=1.0`, `exhaust_cooldown=3600`) が使われます。**正規の運用では `limits` を 4 カテゴリ × 3 キー全て明示してください。**
+設定漏れに対する保険として、`limits.{cat}` または個別キーが欠けている場合はモジュールレベルのハードコード初期値 (`max_inflight=1`, `min_interval=1.0`, `exhaust_cooldown=3600`) が使われます。**正規の運用では `limits` を 5 カテゴリ × 3 キー全て明示してください。**
+
+### `r2v` の取り扱い (lazy-v2.11.1+)
+
+過去の `queue_config.json` には `aliases: {"r2i": "i2i", "r2v": "i2v"}` のように、`r2v` (reference-to-video) を `i2v` の alias として宣言する設定が含まれていることがあります。
+
+- `lazy-v2.11.1` 以降、`CategoryLimiter` は **コードレベルで `aliases.r2v` を強制的に無視** します。
+- 起動時に `[CategoryLimiter] (instance ...) ignored forbidden alias keys in config (\`aliases.r2v\`): ...` という警告ログが 1 回出力されます。
+- これにより、`r2v` URL は **常に独立した `r2v` カテゴリ** として集計され、`i2v` 枠を消費しません。
+- `queue_config.json` 側の `aliases.r2v` を **削除し、`limits.r2v` を追加すること**を強く推奨します。
+- なお `r2i` (reference-to-image) は引き続き `i2i` の alias として扱われます (アップストリームでは `r2i` の独立レートリミットの有無が未確認のため)。
 
 ## Runtime API (`PATCH /api/config`)
 

--- a/docs/custom-groups.md
+++ b/docs/custom-groups.md
@@ -1,6 +1,6 @@
 # Custom Groups (Endpoint-Pattern Rate Limiting)
 
-`lazy-v2.11.0` 以降、`category_rate_limits` (`t2i` / `i2i` / `t2v` / `i2v` カテゴリ単位の制御) に加えて、**ユーザーが endpoint パターンで定義する独自グループ** に対しても per-group の同時実行数 / インターバル / 429 cooldown を設定できます。
+`lazy-v2.11.0` 以降、`category_rate_limits` (`t2i` / `i2i` / `t2v` / `i2v` / `r2v` カテゴリ単位の制御) に加えて、**ユーザーが endpoint パターンで定義する独自グループ** に対しても per-group の同時実行数 / インターバル / 429 cooldown を設定できます。
 
 ## なぜ必要か
 
@@ -118,7 +118,7 @@ endpoint = https://kamui-code.ai/t2v_sd2/fal/bytedance/seedance-v2.0
 | `i2v_sd2` | `seedance-v2.0` / `seedance-v2.0-fast` | 1 | 10s | 3600s |
 | `r2v_sd2` | `seedance-v2.0-reference` / `seedance-v2.0-fast-reference` | 1 | 10s | 3600s |
 
-なぜ初期同梱かというと、**URL prefix `t2v_sd2` / `i2v_sd2` / `r2v_sd2` が標準カテゴリリスト (`t2i / i2i / t2v / i2v`) に含まれない** ため、`custom_groups` 設定なしでは「未知 endpoint」扱いとなり、dispatcher が rate-limit accounting を一切スキップしてしまうからです。高コストモデルがレートリミットなしで野放しになるのは安全とは言えないため、保守的なデフォルトを最初から入れています。
+なぜ初期同梱かというと、**URL prefix `t2v_sd2` / `i2v_sd2` / `r2v_sd2` が標準カテゴリリスト (`t2i / i2i / t2v / i2v / r2v`) に含まれない** ため、`custom_groups` 設定なしでは「未知 endpoint」扱いとなり、dispatcher が rate-limit accounting を一切スキップしてしまうからです。高コストモデルがレートリミットなしで野放しになるのは安全とは言えないため、保守的なデフォルトを最初から入れています。
 
 これらの値は実運用での挙動を見て自由に調整してください。
 


### PR DESCRIPTION
## Summary

- **r2v を独立カテゴリに昇格**: アップストリーム MCP サービスが r2v を i2v と独立にレートリミットしていることが確認されたため、alias (`r2v → i2v`) を廃止し r2v を独立カテゴリ化
- **`FORBIDDEN_ALIASES` 機構**: 旧 queue_config.json に `aliases.r2v` が残っていても起動時に自動削除 + 警告。利用者の config 編集なしで正しい挙動に
- r2i (reference-to-image) は **保守的に alias のまま温存** (アップストリーム独立化未確認)
- pytest 415 → 418 (+3 tests, all pass)

## Why

旧設計では `r2v` URL が `i2v` 枠を消費していたため、r2v ジョブを大量に投げると i2v 側で予期しない 429 を誘発する可能性がありました。アップストリーム側がカテゴリ別ローリング窓レートリミットを別々に運用していることが確定したので、クライアント側もそれに合わせます。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `category_limiter.py` | `KNOWN_CATEGORIES` に r2v 追加 / `DEFAULT_ALIASES` から r2v 削除 / 新規 `FORBIDDEN_ALIASES` + `__init__` で user aliases から強制削除 + warning |
| `generate_skill.py` | デフォルト config に r2v 追加 (categories / limits) |
| `queue_config.example.json` | 同上 |
| `mcp_async_call.py` | `--pause-category` help を `(t2i, i2i, t2v, i2v, r2v)` に |
| `custom_group_limiter.py` | docstring の category 列挙に r2v 追加 |
| `tests/test_category_limiter.py` | r2v alias テストを独立カテゴリテストに置換 / 新規 `TestForbiddenAliases` 3 tests / `TestPublicCategoryAPI` の並び順を 5 カテゴリ対応 |
| `docs/category-limits.md` | r2v 新規セクション + 例の categories/aliases 修正 |
| `docs/custom-groups.md` | category 列挙更新 |
| `CHANGELOG.md` | `[lazy-v2.11.1] (2026-05-10)` セクション新設 |

## 後方互換

- 既存 `queue_config.json` (`aliases.r2v: "i2v"` を含む) はそのまま動作
- 起動時に warning が 1 回出力され、r2v は独立カテゴリとして集計される
- 利用者は queue_config.json の `aliases.r2v` を削除 + `limits.r2v` 追加を推奨 (動作は自動で正しくなりますが、設定ファイルが意図と一致するほうが望ましい)

## Test plan

- [x] `pytest .claude/skills/mcp-async-skill/scripts/tests/ -q` → 418 passed (was 415)
- [x] 新規 `TestForbiddenAliases` 3 tests pass
- [x] `test_extracts_r2v_as_independent_category` で `r2v → r2v` を確認
- [x] `test_aliases_r2i_to_i2i` は引き続き pass (r2i は温存)
- [x] CI guard (`no-generated-skills.yml`) trigger 確認

## Related

- 親 Issue: lazy-v2.11.0 リリース後の運用検証で判明
- 次の release: lazy-v2.11.1 (patch) として CHANGELOG に追記済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)