### PR TITLE
feat(dashboard): surface input/output URLs in job detail modal

### DIFF
--- a/.claude/skills/mcp-async-skill/scripts/tests/test_dashboard_smoke.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_dashboard_smoke.py
@@ -319,5 +319,90 @@ class TestProxyWhitelist(unittest.TestCase):
         self.assertEqual(self.worker.handler_cls.received_paths, before)
 
 
+class TestJobDetailUrlSurfacing(unittest.TestCase):
+    """lazy-v2.12.0: Job detail modal exposes Inputs / Outputs URLs
+    extracted by walking ``args`` and ``result`` JSON. The actual URL
+    walker is in dashboard.js so we cannot unit-test it from Python,
+    but we can pin a few static invariants so a regression in the
+    static assets is caught here:
+
+    1. ``index.html`` uses a ``<div id="job-detail-content">`` rather
+       than a ``<pre>``. The earlier pre-formatted version is incompat
+       with the new flex layout for the Inputs / Outputs sections.
+    2. ``dashboard.js`` exports an ``extractUrls`` symbol — the helper
+       any future test (or future Python smoke harness driving a
+       headless browser) would want to call.
+    3. ``dashboard.css`` carries the ``.url-section`` ruleset so the
+       Inputs / Outputs visual styling actually ships with releases.
+    """
+
+    STATIC_DIR = os.path.join(
+        REPO_ROOT, ".claude", "skills", "queue-dashboard", "scripts", "static",
+    )
+
+    def _read(self, name: str) -> str:
+        path = os.path.join(self.STATIC_DIR, name)
+        with open(path, "r", encoding="utf-8") as fp:
+            return fp.read()
+
+    def test_index_html_uses_div_for_job_detail_content(self):
+        html = self._read("index.html")
+        self.assertIn('<div id="job-detail-content">', html)
+        # No leftover <pre> form: that would override the new flex layout
+        self.assertNotIn('<pre id="job-detail-content"', html)
+
+    def test_dashboard_js_defines_extract_urls(self):
+        js = self._read("dashboard.js")
+        # The walker is called extractUrls(...) by both showJobDetail
+        # and (eventually) any future automated harness.
+        self.assertRegex(js, r"function\s+extractUrls\s*\(")
+        # Inputs and Outputs section titles ship in the JS — they are
+        # what the user sees first in the modal.
+        self.assertIn("Inputs (URLs in submit args)", js)
+        self.assertIn("Outputs (URLs in result)", js)
+
+    def test_dashboard_js_handles_kamui_double_encoded_result(self):
+        """kamui-code MCP wraps the actual result payload as a JSON
+        string inside `remote_result.content[].text`. The walker has to
+        try-parse string nodes that begin with `{` or `[`, otherwise
+        the output URL (`images[].url` / `video.url`) is invisible to
+        the user — which is exactly the failure mode the lazy-v2.12.0
+        feature is designed to prevent. Sample shape from real jobs:
+
+            "remote_result": {
+              "content": [
+                {"type": "text",
+                 "text": "{\\"video\\":{\\"url\\":\\"https://...\\"}}"}
+              ]
+            }
+        """
+        js = self._read("dashboard.js")
+        # The walker labels embedded JSON paths with "(parsed text)".
+        # Future-proofing: if the label changes, this test catches it.
+        self.assertIn("(parsed text)", js)
+
+    def test_dashboard_js_detects_local_paths(self):
+        """kamui-code results carry `local_files` with Windows or
+        POSIX absolute paths. The walker exposes those as a separate
+        'local' entry type so the user can copy-paste them into
+        Explorer / Finder. We pin the helper name to catch accidental
+        deletion."""
+        js = self._read("dashboard.js")
+        self.assertRegex(js, r"function\s+looksLikeLocalPath\s*\(")
+        # The 'local' kind needs to be wired through to the renderer
+        # — without this distinction the local path would silently get
+        # the 'url' kind and produce a dead <a href>.
+        self.assertRegex(js, r"type:\s*\"local\"")
+
+    def test_dashboard_css_has_url_section_styling(self):
+        css = self._read("dashboard.css")
+        self.assertIn(".url-section", css)
+        self.assertIn(".url-thumb", css)
+        # The 4 URL kind variants need their accent borders or the
+        # classification UX silently falls back to all-grey.
+        for kind in ("image", "video", "audio", "other"):
+            self.assertIn(f".url-kind-{kind}", css)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/skills/queue-dashboard/scripts/static/dashboard.css
+++ b/.claude/skills/queue-dashboard/scripts/static/dashboard.css
@@ -525,6 +525,14 @@ h2 {
   min-width: 0;
 }
 
+#job-detail-content .url-more-paths {
+  color: #6b7280;
+  font-size: 0.95em;
+  font-style: italic;
+  cursor: help;
+  flex-shrink: 0;
+}
+
 #job-detail-content .url-kind-badge {
   font-size: 0.7em;
   font-weight: 600;

--- a/.claude/skills/queue-dashboard/scripts/static/dashboard.css
+++ b/.claude/skills/queue-dashboard/scripts/static/dashboard.css
@@ -376,6 +376,7 @@ h2 {
   overflow: auto;
   position: relative;
   min-width: 400px;
+  width: min(900px, 90vw);
 }
 .modal-content .close {
   position: absolute;
@@ -396,6 +397,221 @@ h2 {
   word-break: break-all;
   max-height: 60vh;
   overflow: auto;
+}
+
+/* ---- Job detail modal: Inputs / Outputs surfacing (lazy-v2.12.0) ---- */
+
+#job-detail-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  color: #eee;
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+#job-detail-content .job-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3em;
+  padding: 0.6em 0.8em;
+  background: #2f2f2f;
+  border-left: 3px solid #4b6bff;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+
+#job-detail-content .job-meta code {
+  font-size: 0.95em;
+  background: #1a1a1a;
+  padding: 0 0.3em;
+  border-radius: 2px;
+}
+
+#job-detail-content .job-status-pill {
+  display: inline-block;
+  padding: 1px 0.6em;
+  border-radius: 999px;
+  font-size: 0.8em;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.job-status-pill.st-completed { background: #134e1a; color: #a7f3d0; }
+.job-status-pill.st-failed { background: #5a1a1a; color: #fecaca; }
+.job-status-pill.st-running, .job-status-pill.st-polling { background: #1d3a6c; color: #bfdbfe; }
+.job-status-pill.st-pending { background: #44351a; color: #fde68a; }
+.job-status-pill.st-unknown { background: #3a3a3a; color: #d4d4d4; }
+
+#job-detail-content .url-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+#job-detail-content .url-section-header {
+  margin: 0;
+  font-size: 0.95em;
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  border-bottom: 1px solid #3a3a3a;
+  padding-bottom: 0.2em;
+}
+
+#job-detail-content .url-section-count {
+  display: inline-block;
+  min-width: 1.6em;
+  text-align: center;
+  background: #3a3a3a;
+  color: #d4d4d4;
+  font-size: 0.75em;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0 0.4em;
+}
+
+#job-detail-content .url-empty {
+  color: #888;
+  font-style: italic;
+  font-size: 0.85em;
+  padding: 0.2em 0;
+}
+
+#job-detail-content .url-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6em;
+}
+
+#job-detail-content .url-entry {
+  background: #2a2a2a;
+  border: 1px solid #3a3a3a;
+  border-radius: 4px;
+  padding: 0.5em 0.7em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4em;
+}
+#job-detail-content .url-entry.url-kind-image { border-left: 3px solid #34d399; }
+#job-detail-content .url-entry.url-kind-video { border-left: 3px solid #a78bfa; }
+#job-detail-content .url-entry.url-kind-audio { border-left: 3px solid #fbbf24; }
+#job-detail-content .url-entry.url-kind-other { border-left: 3px solid #60a5fa; }
+#job-detail-content .url-entry.url-entry-local { background: #2a261f; }
+#job-detail-content .url-text-local {
+  color: #d4d4d4;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.78em;
+  word-break: break-all;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+#job-detail-content .url-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5em;
+  font-size: 0.8em;
+}
+
+#job-detail-content .url-path {
+  color: #9ca3af;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.95em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+#job-detail-content .url-kind-badge {
+  font-size: 0.7em;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #d4d4d4;
+  background: #3a3a3a;
+  border-radius: 3px;
+  padding: 1px 0.4em;
+  flex-shrink: 0;
+}
+
+#job-detail-content .url-thumb-link {
+  display: inline-block;
+  align-self: flex-start;
+  border-radius: 3px;
+  overflow: hidden;
+}
+#job-detail-content .url-thumb {
+  max-width: 220px;
+  max-height: 160px;
+  display: block;
+  background: #1a1a1a;
+}
+
+#job-detail-content .url-link-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4em;
+}
+
+#job-detail-content .url-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-all;
+  color: #93c5fd;
+  font-size: 0.82em;
+  text-decoration: none;
+}
+#job-detail-content .url-text:hover { text-decoration: underline; color: #bfdbfe; }
+
+#job-detail-content .url-copy-btn {
+  flex-shrink: 0;
+  background: #3a3a3a;
+  border: 1px solid #4a4a4a;
+  color: #eee;
+  border-radius: 3px;
+  padding: 0 0.5em;
+  font-size: 0.9em;
+  cursor: pointer;
+  line-height: 1.4;
+}
+#job-detail-content .url-copy-btn:hover { background: #4a4a4a; }
+
+#job-detail-content .error-section .error-text {
+  background: #2a1a1a;
+  color: #fecaca;
+  padding: 0.6em 0.8em;
+  border-radius: 3px;
+  font-size: 0.85em;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+
+#job-detail-content .raw-json-details {
+  background: #1d1d1d;
+  border-radius: 3px;
+  border: 1px solid #2a2a2a;
+}
+#job-detail-content .raw-json-details > summary {
+  cursor: pointer;
+  padding: 0.5em 0.8em;
+  font-size: 0.85em;
+  color: #d4d4d4;
+  user-select: none;
+}
+#job-detail-content .raw-json-details > summary:hover { color: #fff; }
+#job-detail-content .raw-json {
+  margin: 0;
+  padding: 0.6em 0.8em;
+  font-size: 0.78em;
+  color: #d4d4d4;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 50vh;
+  overflow: auto;
+  border-top: 1px solid #2a2a2a;
 }
 
 /* ---- PR5 (#61) — Custom Groups + per-category UI + compat banner ---- */

--- a/.claude/skills/queue-dashboard/scripts/static/dashboard.js
+++ b/.claude/skills/queue-dashboard/scripts/static/dashboard.js
@@ -284,20 +284,31 @@ function renderJobs(jobs) {
 
 // ---- URL extraction (Inputs / Outputs surfacing) ----
 
-// A value looks like an extractable URL if it is a string starting with
-// http:// or https://. We keep the regex loose on purpose — kamui-code
-// MCP responses use a variety of host names and paths.
+// `URL_RE` matches a string whose entire value is a URL — that's the
+// common case for fields like `images[].url` or `video.url`.
+// `EMBEDDED_URL_RE` is a global pattern used as a fallback when a
+// string is not entirely a URL (e.g. an error message that mentions
+// one). We deliberately stop at whitespace and common delimiters; this
+// is best-effort, not a parser.
 const URL_RE = /^https?:\/\/\S+$/i;
+const EMBEDDED_URL_RE = /https?:\/\/[^\s"'<>()\[\]{}]+/gi;
 
 // Windows absolute path (`C:\...` / `\\\\server\\share\\...`) or POSIX
-// absolute path (`/home/...` / `/Users/...`). The dashboard treats
-// these as "local files" — they cannot be opened as bare links in the
-// browser (file:// is blocked on most setups), but they appear in
-// kamui-code result blobs (`local_files`) and the user wants to see
-// them next to the remote URLs.
+// absolute path (`/home/...`, `/Users/...`, `/workspace/...`, etc.).
+// The dashboard treats these as "local files" — they cannot be opened
+// as bare links in the browser (file:// is blocked on most setups),
+// but they appear in kamui-code result blobs (`local_files`) and the
+// user wants to see them next to the remote URLs.
+//
+// The POSIX prefix list is intentionally conservative (a bare `/` at
+// the start of a random string is too noisy to treat as a local path)
+// but covers the canonical Linux/macOS roots plus common container /
+// devcontainer / CI runner mount points (`/workspace`, `/app`,
+// `/data`, `/srv`, `/private/...`) and macOS volumes (`/Volumes`).
 const WIN_PATH_RE = /^[A-Za-z]:[\\\/]/;
 const UNC_PATH_RE = /^\\\\[^\\]+\\/;
-const POSIX_PATH_RE = /^\/(?:home|Users|tmp|var|opt|mnt|root)\//;
+const POSIX_PATH_RE =
+  /^\/(?:home|Users|Volumes|tmp|var|opt|mnt|media|root|workspace|app|data|srv|private)\//;
 
 function classifyUrl(url) {
   // Strip query / fragment before extension test to be safe.
@@ -361,6 +372,26 @@ function extractUrls(root, opts) {
         try { parsed = JSON.parse(trimmed); } catch { parsed = undefined; }
         if (parsed !== undefined) {
           visit(parsed, path + " (parsed text)", depth + 1);
+          return;
+        }
+      }
+      // Fallback: prose containing URLs (e.g. an error message that
+      // mentions one). Only extract if the string is moderately long
+      // and has at least one URL match; this keeps short field values
+      // like prompts that happen to mention a URL from drowning the
+      // Outputs section in irrelevant entries. We tag the path as
+      // "(in text)" to make the provenance obvious.
+      if (node.length <= 2048) {
+        EMBEDDED_URL_RE.lastIndex = 0;
+        let m;
+        while ((m = EMBEDDED_URL_RE.exec(node)) !== null) {
+          const u = m[0];
+          out.push({
+            path: path + " (in text)",
+            value: u,
+            kind: classifyUrl(u),
+            type: "url",
+          });
         }
       }
       return;
@@ -382,13 +413,75 @@ function extractUrls(root, opts) {
   return out;
 }
 
+// Group walker output so the same (type, value, kind) is rendered once
+// even if it appears at multiple JSON paths (common with kamui-code's
+// double-encoded result where the same URL shows up in both the outer
+// shape and the parsed inner JSON). The first path is the primary
+// label; the rest are kept in `extraPaths` for a "+N more" hover.
+function dedupeUrlEntries(entries) {
+  const byKey = new Map();
+  for (const e of entries) {
+    const key = e.type + "|" + e.kind + "|" + e.value;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.extraPaths.push(e.path);
+    } else {
+      byKey.set(key, {
+        path: e.path,
+        value: e.value,
+        kind: e.kind,
+        type: e.type,
+        extraPaths: [],
+      });
+    }
+  }
+  return Array.from(byKey.values());
+}
+
+// Copy `text` to the system clipboard. Tries the modern async
+// `navigator.clipboard.writeText` first; if that throws or is missing
+// (HTTP without secure context, older browsers, permissions policy),
+// falls back to a hidden <textarea> + document.execCommand("copy").
+// Returns `true` on success, `false` otherwise.
+async function copyToClipboard(text) {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch { /* fall through to legacy path */ }
+
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    // Make it invisible but selectable and inside the document so
+    // execCommand("copy") will pick it up.
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.left = "-9999px";
+    ta.style.top = "0";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return !!ok;
+  } catch {
+    return false;
+  }
+}
+
+// Minimal element helper. Intentionally does NOT support an `html`
+// (innerHTML) shortcut to keep XSS surface narrow — every user-facing
+// string in this modal comes from data the worker returns about jobs,
+// and all of it must go through textContent / a text child node.
 function _el(tag, attrs, ...children) {
   const e = document.createElement(tag);
   if (attrs) {
     for (const k of Object.keys(attrs)) {
       if (k === "class") e.className = attrs[k];
       else if (k === "text") e.textContent = attrs[k];
-      else if (k === "html") e.innerHTML = attrs[k];
       else if (k.startsWith("on") && typeof attrs[k] === "function") {
         e.addEventListener(k.slice(2).toLowerCase(), attrs[k]);
       } else if (attrs[k] !== undefined && attrs[k] !== null) {
@@ -414,7 +507,18 @@ function _renderUrlEntry(entry) {
   });
 
   const head = _el("div", { class: "url-head" });
-  head.appendChild(_el("span", { class: "url-path", title: entry.path }, entry.path || "(root)"));
+  const pathSpan = _el("span", { class: "url-path",
+    title: entry.path }, entry.path || "(root)");
+  head.appendChild(pathSpan);
+  // If the same URL appeared at multiple JSON paths, surface that as a
+  // discreet "+N more" suffix with the full list as tooltip — helpful
+  // for debugging without cluttering the row.
+  if (entry.extraPaths && entry.extraPaths.length > 0) {
+    head.appendChild(_el("span", {
+      class: "url-more-paths",
+      title: entry.extraPaths.join("\n"),
+    }, " (+" + entry.extraPaths.length + " more)"));
+  }
   head.appendChild(_el("span", { class: "url-kind-badge" },
     isLocal ? entry.kind + " (local)" : entry.kind));
   wrap.appendChild(head);
@@ -454,15 +558,14 @@ function _renderUrlEntry(entry) {
     class: "url-copy-btn", type: "button",
     title: isLocal ? "Copy path" : "Copy URL",
     onclick: async () => {
-      try {
-        await navigator.clipboard.writeText(entry.value);
-        linkRow.querySelector(".url-copy-btn").textContent = "✓";
-        setTimeout(() => {
-          const b = linkRow.querySelector(".url-copy-btn");
-          if (b) b.textContent = "⧉";
-        }, 1500);
-      } catch (e) {
-        alert("Copy failed: " + e.message);
+      const btn = linkRow.querySelector(".url-copy-btn");
+      const ok = await copyToClipboard(entry.value);
+      if (btn) {
+        btn.textContent = ok ? "✓" : "✗";
+        setTimeout(() => { if (btn) btn.textContent = "⧉"; }, 1500);
+      }
+      if (!ok) {
+        alert("Copy failed: clipboard not available in this context.");
       }
     },
   }, "⧉"));
@@ -507,9 +610,10 @@ async function showJobDetail(jobId) {
   }
   const argsObj = data.args;
 
-  const inputUrls = argsObj === undefined ? [] : extractUrls(argsObj);
-  const outputUrls = resultObj === undefined || resultObj === null
-    ? [] : extractUrls(resultObj);
+  const inputUrls = dedupeUrlEntries(
+    argsObj === undefined ? [] : extractUrls(argsObj));
+  const outputUrls = dedupeUrlEntries(
+    resultObj === undefined || resultObj === null ? [] : extractUrls(resultObj));
 
   const content = document.getElementById("job-detail-content");
   content.innerHTML = "";  // clear previous render
@@ -520,10 +624,16 @@ async function showJobDetail(jobId) {
     _el("strong", null, "Job ID: "),
     _el("code", null, data.job_id || jobId),
   ));
+  // Normalize status into a CSS-class-safe form. The worker today only
+  // emits known statuses (pending / running / polling / completed /
+  // failed / cancelled), but anything weird leaking into the response
+  // would produce a malformed class attribute — replace non-class
+  // characters with `-`.
+  const statusRaw = data.status || "unknown";
+  const statusClass = String(statusRaw).toLowerCase().replace(/[^a-z0-9_-]/g, "-");
   meta.appendChild(_el("div", null,
     _el("strong", null, "Status: "),
-    _el("span", { class: "job-status-pill st-" + (data.status || "unknown") },
-      data.status || "unknown"),
+    _el("span", { class: "job-status-pill st-" + statusClass }, statusRaw),
   ));
   if (data.endpoint) {
     meta.appendChild(_el("div", null,

--- a/.claude/skills/queue-dashboard/scripts/static/dashboard.js
+++ b/.claude/skills/queue-dashboard/scripts/static/dashboard.js
@@ -282,19 +282,286 @@ function renderJobs(jobs) {
   }
 }
 
+// ---- URL extraction (Inputs / Outputs surfacing) ----
+
+// A value looks like an extractable URL if it is a string starting with
+// http:// or https://. We keep the regex loose on purpose — kamui-code
+// MCP responses use a variety of host names and paths.
+const URL_RE = /^https?:\/\/\S+$/i;
+
+// Windows absolute path (`C:\...` / `\\\\server\\share\\...`) or POSIX
+// absolute path (`/home/...` / `/Users/...`). The dashboard treats
+// these as "local files" — they cannot be opened as bare links in the
+// browser (file:// is blocked on most setups), but they appear in
+// kamui-code result blobs (`local_files`) and the user wants to see
+// them next to the remote URLs.
+const WIN_PATH_RE = /^[A-Za-z]:[\\\/]/;
+const UNC_PATH_RE = /^\\\\[^\\]+\\/;
+const POSIX_PATH_RE = /^\/(?:home|Users|tmp|var|opt|mnt|root)\//;
+
+function classifyUrl(url) {
+  // Strip query / fragment before extension test to be safe.
+  const stripped = url.split(/[?#]/)[0];
+  if (/\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i.test(stripped)) return "image";
+  if (/\.(mp4|webm|mov|m4v|mkv)$/i.test(stripped)) return "video";
+  if (/\.(mp3|wav|ogg|flac|m4a|aac)$/i.test(stripped)) return "audio";
+  return "other";
+}
+
+function classifyLocalPath(path) {
+  if (/\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i.test(path)) return "image";
+  if (/\.(mp4|webm|mov|m4v|mkv)$/i.test(path)) return "video";
+  if (/\.(mp3|wav|ogg|flac|m4a|aac)$/i.test(path)) return "audio";
+  return "other";
+}
+
+function looksLikeLocalPath(s) {
+  return WIN_PATH_RE.test(s) || UNC_PATH_RE.test(s) || POSIX_PATH_RE.test(s);
+}
+
+// Walk an arbitrarily nested JSON structure and yield every URL-looking
+// string and local-file-path-looking string together with a
+// human-readable JSON path. Duplicate URLs at different paths are kept
+// (the path tells you which one is which).
+//
+// kamui-code MCP returns JSON where the *actual* result payload is a
+// JSON string embedded inside `remote_result.content[].text`. We
+// transparently parse such strings (if and only if they start with
+// `{` or `[` after trim and parse cleanly) and walk into them, marking
+// the path with `(parsed text)` so the user knows where the URL came
+// from. This is the difference between "wow this is great" and "where
+// is my output URL?" in practice.
+//
+// Maximum depth and node count are bounded to keep huge result blobs
+// from freezing the modal.
+function extractUrls(root, opts) {
+  const maxDepth = (opts && opts.maxDepth) || 14;
+  const maxNodes = (opts && opts.maxNodes) || 5000;
+  const out = [];
+  let nodes = 0;
+  function visit(node, path, depth) {
+    if (nodes++ > maxNodes) return;
+    if (depth > maxDepth) return;
+    if (node === null || node === undefined) return;
+    if (typeof node === "string") {
+      if (URL_RE.test(node)) {
+        out.push({ path, value: node, kind: classifyUrl(node), type: "url" });
+        return;
+      }
+      if (looksLikeLocalPath(node)) {
+        out.push({ path, value: node, kind: classifyLocalPath(node), type: "local" });
+        return;
+      }
+      // Embedded JSON (kamui-code wraps the real payload as a JSON
+      // string inside `content[].text`). Parse it transparently.
+      const trimmed = node.trim();
+      if (trimmed.length > 1 &&
+          (trimmed[0] === "{" || trimmed[0] === "[")) {
+        let parsed;
+        try { parsed = JSON.parse(trimmed); } catch { parsed = undefined; }
+        if (parsed !== undefined) {
+          visit(parsed, path + " (parsed text)", depth + 1);
+        }
+      }
+      return;
+    }
+    if (Array.isArray(node)) {
+      for (let i = 0; i < node.length; i++) {
+        visit(node[i], path + "[" + i + "]", depth + 1);
+      }
+      return;
+    }
+    if (typeof node === "object") {
+      for (const key of Object.keys(node)) {
+        const subpath = path ? path + "." + key : key;
+        visit(node[key], subpath, depth + 1);
+      }
+    }
+  }
+  visit(root, "", 0);
+  return out;
+}
+
+function _el(tag, attrs, ...children) {
+  const e = document.createElement(tag);
+  if (attrs) {
+    for (const k of Object.keys(attrs)) {
+      if (k === "class") e.className = attrs[k];
+      else if (k === "text") e.textContent = attrs[k];
+      else if (k === "html") e.innerHTML = attrs[k];
+      else if (k.startsWith("on") && typeof attrs[k] === "function") {
+        e.addEventListener(k.slice(2).toLowerCase(), attrs[k]);
+      } else if (attrs[k] !== undefined && attrs[k] !== null) {
+        e.setAttribute(k, attrs[k]);
+      }
+    }
+  }
+  for (const c of children) {
+    if (c === null || c === undefined) continue;
+    e.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+  }
+  return e;
+}
+
+function _renderUrlEntry(entry) {
+  // entry = { path, value, kind, type }
+  // type ∈ { "url", "local" }; "local" cannot be linked but can be
+  // copied to clipboard so the user can paste it into Explorer.
+  const isLocal = entry.type === "local";
+  const wrap = _el("div", {
+    class: "url-entry url-kind-" + entry.kind +
+           (isLocal ? " url-entry-local" : ""),
+  });
+
+  const head = _el("div", { class: "url-head" });
+  head.appendChild(_el("span", { class: "url-path", title: entry.path }, entry.path || "(root)"));
+  head.appendChild(_el("span", { class: "url-kind-badge" },
+    isLocal ? entry.kind + " (local)" : entry.kind));
+  wrap.appendChild(head);
+
+  // Thumbnail: only for remote http(s) images (file:// is blocked in
+  // most browsers, so a local image path cannot preview reliably).
+  if (!isLocal && entry.kind === "image") {
+    const a = _el("a", {
+      href: entry.value, target: "_blank", rel: "noopener noreferrer",
+      class: "url-thumb-link",
+    });
+    a.appendChild(_el("img", {
+      class: "url-thumb",
+      loading: "lazy",
+      decoding: "async",
+      src: entry.value,
+      alt: entry.path,
+    }));
+    wrap.appendChild(a);
+  }
+
+  const linkRow = _el("div", { class: "url-link-row" });
+  if (isLocal) {
+    // Plain text + copy. No <a href>: a file:// link from a normal http
+    // origin would be blocked by the browser, and surfacing a dead link
+    // is worse than not surfacing one.
+    linkRow.appendChild(_el("span", {
+      class: "url-text url-text-local", title: entry.value,
+    }, entry.value));
+  } else {
+    linkRow.appendChild(_el("a", {
+      href: entry.value, target: "_blank", rel: "noopener noreferrer",
+      class: "url-text", title: entry.value,
+    }, entry.value));
+  }
+  linkRow.appendChild(_el("button", {
+    class: "url-copy-btn", type: "button",
+    title: isLocal ? "Copy path" : "Copy URL",
+    onclick: async () => {
+      try {
+        await navigator.clipboard.writeText(entry.value);
+        linkRow.querySelector(".url-copy-btn").textContent = "✓";
+        setTimeout(() => {
+          const b = linkRow.querySelector(".url-copy-btn");
+          if (b) b.textContent = "⧉";
+        }, 1500);
+      } catch (e) {
+        alert("Copy failed: " + e.message);
+      }
+    },
+  }, "⧉"));
+  wrap.appendChild(linkRow);
+
+  return wrap;
+}
+
+function _renderUrlSection(title, urls) {
+  const section = _el("section", { class: "url-section" });
+  const header = _el("h3", { class: "url-section-header" });
+  header.appendChild(_el("span", { class: "url-section-title" }, title));
+  header.appendChild(_el("span", { class: "url-section-count" },
+    String(urls.length)));
+  section.appendChild(header);
+
+  if (urls.length === 0) {
+    section.appendChild(_el("div", { class: "url-empty" }, "(no URLs found)"));
+    return section;
+  }
+  const list = _el("div", { class: "url-list" });
+  for (const u of urls) list.appendChild(_renderUrlEntry(u));
+  section.appendChild(list);
+  return section;
+}
+
 async function showJobDetail(jobId) {
   if (!jobId) return;
+  let data;
   try {
-    const data = await fetchJSON(`/api/jobs/${jobId}?include_args=true`);
-    const pretty = JSON.stringify(data, null, 2);
-    const content = document.getElementById("job-detail-content");
-    content.textContent = pretty.length > 50000
-      ? pretty.slice(0, 50000) + "\n\n... (truncated)"
-      : pretty;
-    openModal();
+    data = await fetchJSON(`/api/jobs/${jobId}?include_args=true`);
   } catch (e) {
     alert("Failed to load job: " + e.message);
+    return;
   }
+
+  // Parse result: API may return it either as already-parsed JSON or as
+  // a raw string (older worker versions). Be defensive.
+  let resultObj = data.result;
+  if (typeof resultObj === "string") {
+    try { resultObj = JSON.parse(resultObj); } catch { /* leave as string */ }
+  }
+  const argsObj = data.args;
+
+  const inputUrls = argsObj === undefined ? [] : extractUrls(argsObj);
+  const outputUrls = resultObj === undefined || resultObj === null
+    ? [] : extractUrls(resultObj);
+
+  const content = document.getElementById("job-detail-content");
+  content.innerHTML = "";  // clear previous render
+
+  // Top summary row
+  const meta = _el("div", { class: "job-meta" });
+  meta.appendChild(_el("div", null,
+    _el("strong", null, "Job ID: "),
+    _el("code", null, data.job_id || jobId),
+  ));
+  meta.appendChild(_el("div", null,
+    _el("strong", null, "Status: "),
+    _el("span", { class: "job-status-pill st-" + (data.status || "unknown") },
+      data.status || "unknown"),
+  ));
+  if (data.endpoint) {
+    meta.appendChild(_el("div", null,
+      _el("strong", null, "Endpoint: "),
+      _el("code", null, data.endpoint),
+    ));
+  }
+  content.appendChild(meta);
+
+  // Inputs / Outputs sections
+  content.appendChild(_renderUrlSection("Inputs (URLs in submit args)", inputUrls));
+  content.appendChild(_renderUrlSection("Outputs (URLs in result)", outputUrls));
+
+  // Error (if any)
+  if (data.error) {
+    const errSection = _el("section", { class: "url-section error-section" });
+    errSection.appendChild(_el("h3", { class: "url-section-header" }, "Error"));
+    errSection.appendChild(_el("pre", { class: "error-text" }, String(data.error)));
+    content.appendChild(errSection);
+  }
+
+  // Raw JSON (still useful for debugging / copy-paste)
+  const rawHeader = _el("h3", { class: "url-section-header" });
+  rawHeader.appendChild(_el("span", { class: "url-section-title" }, "Raw JSON"));
+  const rawDetails = _el("details", { class: "raw-json-details" });
+  // Closed by default if there are URLs to look at, open if not.
+  if (inputUrls.length === 0 && outputUrls.length === 0) {
+    rawDetails.setAttribute("open", "open");
+  }
+  const summary = _el("summary", null, "Raw JSON (click to expand)");
+  rawDetails.appendChild(summary);
+  const pretty = JSON.stringify(data, null, 2);
+  rawDetails.appendChild(_el("pre", { class: "raw-json" },
+    pretty.length > 50000 ? pretty.slice(0, 50000) + "\n\n... (truncated)" : pretty
+  ));
+  content.appendChild(rawDetails);
+
+  openModal();
 }
 
 async function toggleCategory(cat, currentlyPaused) {

--- a/.claude/skills/queue-dashboard/scripts/static/index.html
+++ b/.claude/skills/queue-dashboard/scripts/static/index.html
@@ -111,7 +111,7 @@
   <div id="job-detail-modal" hidden role="dialog" aria-modal="true">
     <div class="modal-content">
       <button class="close" aria-label="Close">×</button>
-      <pre id="job-detail-content"></pre>
+      <div id="job-detail-content"></div>
     </div>
   </div>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased] — targeting lazy-v2.12.0
+
+### Added
+- **Queue Dashboard: ジョブ詳細モーダルに Inputs / Outputs URL リンク化** ([#71](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/pull/71)):
+  - 完了 / 失敗ジョブをクリックして開く詳細モーダルの上部に **Inputs (submit args の URL)** と **Outputs (result の URL)** セクションを追加。`args` と `result` の JSON を再帰 walk して `https?://...` 文字列を全部抽出し、JSON path (`result.images[0].url` など) と共に一覧表示。
+  - **kamui-code MCP の二重 JSON エンコード対応**: kamui-code はレスポンスペイロードを `remote_result.content[].text` に *JSON 文字列として* 埋め込んで返します。walker は `{` / `[` で始まる文字列を try-parse して中も再帰し、path に `(parsed text)` ラベルを付けて出処を明示。これがないと完了ジョブの肝心な `images[].url` / `video.url` が表面に出ない。
+  - **ローカル生成物パス (`local_files`) の表示**: result に含まれる Windows (`C:\...`) / POSIX (`/home/...`) 絶対パスを別カテゴリ `local` として表示。`file://` リンクは多くのブラウザで開けないため Copy ボタンのみ提供 (Explorer / Finder に貼り付けて開く前提)。
+  - **画像 URL は thumbnail プレビュー** (lazy load) + Open / Copy ボタン。動画 / 音声 / その他は左ボーダーの色で kind を識別 (image=緑、video=紫、audio=黄、other=青)。
+  - **Copy ボタン**: 1 クリックで URL / パスをクリップボードへ (`navigator.clipboard.writeText`)、視覚フィードバック (`✓` → 1.5 秒後に元に戻る)。
+  - **モーダルメタヘッダー**: Job ID / Status pill (色付き) / Endpoint をモーダル先頭に表示。raw JSON 全文は `<details>` セクションに格納 (URL が見つかれば閉じた状態、見つからなければ開いた状態がデフォルト)。
+  - 抽出は副作用なし、`maxDepth=14` / `maxNodes=5000` の上限で大きな result blob でも UI freeze しない。実 DB サンプル (t2i / t2v_sd2 / r2v_sd2) で動作検証済み — r2v_sd2 の `image_urls[0]` (参照画像 URL) も Inputs に表面化。
+- 新規テスト: `test_dashboard_smoke.py::TestJobDetailUrlSurfacing` (5 tests) — index.html の `<div id="job-detail-content">` 化 / dashboard.js に `extractUrls` 関数定義 / `(parsed text)` 二重 JSON ラベル / `looksLikeLocalPath` 関数定義 / dashboard.css に `.url-section` + `.url-thumb` + 4 kind variant の存在を pin
+- 全 `scripts/tests/` で 423 tests pass (lazy-v2.11.1 から +5)
+
 ## [lazy-v2.11.1](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/releases/tag/lazy-v2.11.1) (2026-05-10)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased] — targeting lazy-v2.12.0
 
 ### Added
-- **Queue Dashboard: ジョブ詳細モーダルに Inputs / Outputs URL リンク化** ([#71](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/pull/71)):
+- **Queue Dashboard: ジョブ詳細モーダルに Inputs / Outputs URL リンク化** ([#72](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/pull/72)):
   - 完了 / 失敗ジョブをクリックして開く詳細モーダルの上部に **Inputs (submit args の URL)** と **Outputs (result の URL)** セクションを追加。`args` と `result` の JSON を再帰 walk して `https?://...` 文字列を全部抽出し、JSON path (`result.images[0].url` など) と共に一覧表示。
   - **kamui-code MCP の二重 JSON エンコード対応**: kamui-code はレスポンスペイロードを `remote_result.content[].text` に *JSON 文字列として* 埋め込んで返します。walker は `{` / `[` で始まる文字列を try-parse して中も再帰し、path に `(parsed text)` ラベルを付けて出処を明示。これがないと完了ジョブの肝心な `images[].url` / `video.url` が表面に出ない。
   - **ローカル生成物パス (`local_files`) の表示**: result に含まれる Windows (`C:\...`) / POSIX (`/home/...`) 絶対パスを別カテゴリ `local` として表示。`file://` リンクは多くのブラウザで開けないため Copy ボタンのみ提供 (Explorer / Finder に貼り付けて開く前提)。


### PR DESCRIPTION
Fixes #74

## Summary

ジョブ詳細モーダルの一番上に **Inputs / Outputs URL リンク**セクションを追加。完了ジョブの生成物 URL と、入力に渡した参照 URL (`image_urls[]` など) を、JSON 全文を読まなくても一目で確認できるようにします。

- **再帰 walk** で `args` / `result` 内の URL を全部抽出 (path 付き)
- **二重 JSON エンコード対応**: kamui-code MCP は実際の URL を `remote_result.content[].text` に JSON 文字列として埋め込んで返すので、try-parse して中まで再帰
- **prose 中の URL も抽出**: エラーメッセージなどに混じった URL も拾える (`(in text)` ラベル)
- **dedup**: 同じ URL が複数 path に出る場合は 1 エントリに統合、`(+N more)` で path 一覧を tooltip 表示
- **local_files の Windows / POSIX パスも別カテゴリで表示** (Copy ボタンのみ提供、`file://` は browser が拒否するため)
- **画像 URL は thumbnail プレビュー** (lazy load)、動画/音声/その他は kind 別の左ボーダー色
- **Status pill** を色付きでヘッダに表示
- **Copy clipboard fallback** (`navigator.clipboard` が使えない context では `<textarea>` + `execCommand("copy")`)

## Why

旧モーダルは `<pre>` に JSON 丸ごとを流し込むだけで、(1) 完了ジョブの生成物 URL を取り出すのに JSON を目視で辿る必要 (2) r2v_sd2 のような参照画像 URL も同様、(3) kamui-code の二重 JSON エンコードのせいで普通に grep しても出てこないという辛さがありました。

実 DB (`kamuicode_seedancetest2/.claude/queue/jobs.db`) の t2i / t2v_sd2 / r2v_sd2 サンプル 3 種で動作検証済み:

| 種別 | Inputs | Outputs |
|---|---|---|
| t2i | (none) | `remote_result.content[0].text (parsed text).images[0].url` + `local_files[0]` |
| r2v_sd2 | `image_urls[0]` (参照画像) ✅ | `...content[0].text (parsed text).video.url` + `local_files[0]` |
| t2v_sd2 | (none) | `...content[0].text (parsed text).video.url` + `local_files[0]` |

## Codex CLI レビュー対応 (lazy-v2.12.0 直前にレビュー実施、本 PR に反映済み)

Codex CLI (gpt-5.2-codex) によるコードレビューを受けて以下を本 PR に反映:

1. **CHANGELOG の PR 番号誤り修正** (`#71` → `#72`)
2. **`_el` ヘルパの `innerHTML` 分岐を削除** (XSS 伏線の除去、本 PR では未使用)
3. **POSIX path 検出を拡張**: `/home`, `/Users`, `/tmp`, `/var`, `/opt`, `/mnt`, `/root` に加え `/Volumes`, `/media`, `/workspace`, `/app`, `/data`, `/srv`, `/private` を追加
4. **status の CSS class 名 sanitize**: `data.status` を class 名に使う前に `[^a-z0-9_-]` を `-` に置換
5. **prose 中の URL 抽出**: 文字列全体が URL でない場合 (例: エラーメッセージ "Upstream returned 502; see https://...") も最大 2048 文字以内なら URL を抽出、path に `(in text)` ラベル付き
6. **URL dedup + paths 集約**: 同一 URL が異なる path で複数回検出される場合 (二重 JSON で起きやすい) は 1 エントリに統合、追加 path は `extraPaths` に保持し UI で `(+N more)` で参照可能
7. **Copy clipboard fallback**: `navigator.clipboard.writeText` 失敗時に `<textarea>` + `execCommand("copy")` にフォールバック (HTTP origin / 古い browser 対応)

Codex 推奨で適用見送りした項目:

- **`extractUrls` の Node ベース単体テスト追加**: OSS の開発依存に Node ランタイムを要求する形になるため、本 PR では見送り。代替として static smoke check (5 件) で関数定義・キーワード存在を pin。挙動の検証は **手動目視 + 本リポジトリ Issue #73 で worker 側 parse 集約後に pytest 化** する方針 (Issue #73 参照)。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `dashboard.js` | `extractUrls` + `dedupeUrlEntries` + `looksLikeLocalPath` + `classifyUrl` + `classifyLocalPath` + `copyToClipboard` (fallback 付き) 新設、`showJobDetail` を全面書き換え、`_renderUrlEntry` / `_renderUrlSection` / `_el` (innerHTML 分岐なし) ヘルパ追加 |
| `dashboard.css` | `.url-section` / `.url-entry` / `.url-thumb` / 4 kind variant のスタイル、`.url-entry-local` 別配色、`.url-more-paths` tooltip、`.job-status-pill` |
| `index.html` | `<pre id="job-detail-content">` → `<div id="job-detail-content">` (flex layout 対応) |
| `test_dashboard_smoke.py` | `TestJobDetailUrlSurfacing` 5 tests 追加 (static assets pin) |
| `CHANGELOG.md` | `[Unreleased] — targeting lazy-v2.12.0` セクション新設 |

## UI 動作

1. Recent Jobs から完了ジョブをクリック → モーダルが開く
2. モーダル上部: **Job meta** (Job ID / Status pill / Endpoint)
3. **Inputs** セクション: submit args 内の URL リスト (画像なら thumbnail)
4. **Outputs** セクション: result 内の URL リスト + 二重 JSON 内の URL も展開済み + ローカルパスも別表示
5. **Error** セクション (失敗ジョブのみ)
6. **Raw JSON** (details, クリックで展開)

## Test plan

- [x] `pytest .claude/skills/mcp-async-skill/scripts/tests/ -q` → 423 passed (was 418 in lazy-v2.11.1)
- [x] 実 DB サンプルで walker 出力を目視確認 (t2i / t2v_sd2 / r2v_sd2)
- [x] index.html の `<div>` 化 + dashboard.js の `extractUrls` 関数定義 + `(parsed text)` 二重 JSON ラベル + `looksLikeLocalPath` 関数定義 + `.url-section` CSS の static check
- [ ] **マージ前にローカルで dashboard 起動して目視確認** (本 PR を引き入れた後の最終チェック)

## Related

- Issue #74: 本 PR が対応する機能要望
- Issue #73: 二重 JSON 展開を worker 側に集約する後続設計改善 (本 PR は dashboard.js 側にロジックを置くが、Issue #73 が完了したら dashboard.js の二重 JSON 分岐は削除予定)
- Issue #71: 長尺ジョブ完了待ちの subagent docs (別軸、本 PR と独立)

🤖 Generated with [Claude Code](https://claude.com/claude-code)