### PR TITLE
feat(worker): normalize job-detail JSON server-side (Fixes #73)

### DIFF
--- a/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
@@ -164,21 +164,30 @@ def _normalize_result_payload(result_raw: object) -> object:
 
 
 def _normalize_args_payload(args_raw: object) -> object:
-    """Mirror of :func:`_normalize_result_payload` for the ``args``
-    column. Today this is just ``json.loads`` with a string fallback;
-    we route it through this helper so future shape-specific
-    annotations can be added in one place. Does **not** expand any
-    embedded ``content[].text`` because submitted args have never
-    historically used that shape, and triggering surprise expansion
-    on a prompt that happens to look like JSON would be a footgun.
+    """Return the ``args`` column ready for the response.
+
+    Behavior is intentionally aligned with the legacy
+    ``json.loads(j["args"])`` path that lived inline in the request
+    handler before Issue #73 — including support for **scalar JSON**
+    values (``"42"``, ``"true"``, ``"null"``, ``"\\"x\\""``) which
+    legacy code parsed successfully. Routing through
+    :func:`_try_json_loads` (which only attempts parse when the
+    string starts with ``{`` or ``[``) would silently change the
+    return type for any consumer that submitted a bare JSON scalar
+    as ``args``.
+
+    Does **not** annotate any embedded ``remote_result.content[].text``
+    because submitted args have never historically used that shape,
+    and triggering surprise expansion on a prompt that happens to
+    look like JSON would be a footgun for round-trip consumers.
     """
     if args_raw is None or args_raw == "":
         return args_raw
     if isinstance(args_raw, str):
-        candidate = _try_json_loads(args_raw)
-        if candidate is None:
+        try:
+            return json.loads(args_raw)
+        except (json.JSONDecodeError, ValueError):
             return args_raw
-        return candidate
     return args_raw
 
 

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
@@ -61,6 +61,125 @@ def _age_seconds(ts: str | None) -> float | None:
     return (datetime.now(timezone.utc) - dt).total_seconds()
 
 
+# Maximum byte length of a `content[].text` field that we'll try to
+# parse as JSON. Above this we leave it alone — the cost of parsing
+# a megabyte of accidental binary-as-text is not worth the chance of
+# finding embedded URLs, and the dashboard already shows the raw text
+# under "Raw JSON".
+_TEXT_PARSE_MAX_BYTES = 1_000_000
+
+
+def _try_json_loads(s: str) -> object | None:
+    """Return ``json.loads(s)`` if *s* looks like a JSON object or array,
+    otherwise return ``None``. Never raises. Used to expand kamui-code
+    MCP's ``content[].text`` payload (which is a JSON-encoded string
+    inside the outer result) so the dashboard does not have to
+    re-implement the parsing client-side.
+
+    Conservative: only attempts parse when the trimmed string starts
+    with ``{`` or ``[``. Bare strings, numbers, prose, etc. are never
+    misinterpreted as embedded JSON.
+    """
+    if not isinstance(s, str):
+        return None
+    if len(s) > _TEXT_PARSE_MAX_BYTES:
+        return None
+    t = s.strip()
+    if not t or t[0] not in ("{", "["):
+        return None
+    try:
+        return json.loads(t)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _annotate_content_text(content: list) -> None:
+    """Walk a ``content`` array (as found under
+    ``remote_result.content`` in kamui-code MCP results) and, for each
+    entry whose ``text`` is a JSON-encoded object/array, set a
+    sibling ``text_parsed`` field with the parsed value.
+
+    Operates **in-place** on the list's dict entries. Single-level
+    expansion only: if ``text_parsed`` itself contains nested
+    JSON-as-string, we do not recurse — keeping the normalization
+    bounded and predictable.
+
+    Defensive: tolerates ``content`` items that are not dicts, missing
+    keys, non-string text, parse failures. None of those should raise
+    or block the response.
+    """
+    if not isinstance(content, list):
+        return
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if not isinstance(text, str):
+            continue
+        parsed = _try_json_loads(text)
+        if parsed is not None:
+            item["text_parsed"] = parsed
+
+
+def _normalize_result_payload(result_raw: object) -> object:
+    """Promote a raw ``result`` value (typically a JSON string from the
+    DB) into a fully-parsed dict, and annotate kamui-code MCP shapes
+    so clients do not need to re-parse ``content[].text`` themselves.
+
+    Behavior:
+
+    * If *result_raw* is ``None`` or ``""`` → returned unchanged.
+    * If *result_raw* is a string that parses as JSON → returns the
+      parsed value; if the parsed value has the
+      ``remote_result.content`` shape, its content entries get
+      ``text_parsed`` annotations (single-level).
+    * If *result_raw* is a string that does not parse as JSON → returned
+      as-is (the response still carries it so the client can decide
+      how to render it). This keeps the response usable even when a
+      job's executor stored unstructured text.
+    * If *result_raw* is already a dict/list (defensive — should not
+      happen via DB roundtrip today, but guards against future code
+      paths that pre-parse) → annotation is still applied.
+    """
+    if result_raw is None or result_raw == "":
+        return result_raw
+    parsed: object
+    if isinstance(result_raw, str):
+        candidate = _try_json_loads(result_raw)
+        if candidate is None:
+            return result_raw  # leave non-JSON string alone
+        parsed = candidate
+    else:
+        parsed = result_raw
+
+    if isinstance(parsed, dict):
+        remote = parsed.get("remote_result")
+        if isinstance(remote, dict):
+            content = remote.get("content")
+            if isinstance(content, list):
+                _annotate_content_text(content)
+    return parsed
+
+
+def _normalize_args_payload(args_raw: object) -> object:
+    """Mirror of :func:`_normalize_result_payload` for the ``args``
+    column. Today this is just ``json.loads`` with a string fallback;
+    we route it through this helper so future shape-specific
+    annotations can be added in one place. Does **not** expand any
+    embedded ``content[].text`` because submitted args have never
+    historically used that shape, and triggering surprise expansion
+    on a prompt that happens to look like JSON would be a footgun.
+    """
+    if args_raw is None or args_raw == "":
+        return args_raw
+    if isinstance(args_raw, str):
+        candidate = _try_json_loads(args_raw)
+        if candidate is None:
+            return args_raw
+        return candidate
+    return args_raw
+
+
 class _RequestHandler(BaseHTTPRequestHandler):
     """HTTP request handler for the worker API."""
 
@@ -144,10 +263,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
                     "error": j["error"],
                 }
                 if include_args:
-                    try:
-                        entry["args"] = json.loads(j["args"])
-                    except (json.JSONDecodeError, TypeError):
-                        entry["args"] = j["args"]
+                    entry["args"] = _normalize_args_payload(j["args"])
                 job_list.append(entry)
             self._send_json(200, {
                 "server_time_utc": _utc_now_iso(),
@@ -253,6 +369,15 @@ class _RequestHandler(BaseHTTPRequestHandler):
                 return
             created_age = _age_seconds(job["created_at"])
             updated_age = _age_seconds(job["updated_at"])
+            # `result` is stored in the DB as a JSON-encoded string. We
+            # used to forward it to the client untouched, leaving every
+            # consumer to re-parse it (and to deal with kamui-code's
+            # double-JSON-encoded `remote_result.content[].text`). As of
+            # Issue #73, the worker is the single place that performs
+            # that normalization so the dashboard (and any future CLI /
+            # client) sees a fully-structured object with `text_parsed`
+            # already populated. See `_normalize_result_payload` for
+            # the rules.
             resp_data = {
                 "server_time_utc": _utc_now_iso(),
                 "job_id": job["id"],
@@ -261,15 +386,12 @@ class _RequestHandler(BaseHTTPRequestHandler):
                 "updated_at": job["updated_at"],
                 "created_age_seconds": round(created_age, 1) if created_age is not None else None,
                 "updated_age_seconds": round(updated_age, 1) if updated_age is not None else None,
-                "result": job["result"],
+                "result": _normalize_result_payload(job["result"]),
                 "error": job["error"],
                 "remote_job_id": job["remote_job_id"],
             }
             if _include_args:
-                try:
-                    resp_data["args"] = json.loads(job["args"])
-                except (json.JSONDecodeError, TypeError):
-                    resp_data["args"] = job["args"]
+                resp_data["args"] = _normalize_args_payload(job["args"])
             self._send_json(200, resp_data)
             return
 

--- a/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
+++ b/.claude/skills/mcp-async-skill/scripts/job_queue/worker.py
@@ -61,14 +61,6 @@ def _age_seconds(ts: str | None) -> float | None:
     return (datetime.now(timezone.utc) - dt).total_seconds()
 
 
-# Maximum byte length of a `content[].text` field that we'll try to
-# parse as JSON. Above this we leave it alone — the cost of parsing
-# a megabyte of accidental binary-as-text is not worth the chance of
-# finding embedded URLs, and the dashboard already shows the raw text
-# under "Raw JSON".
-_TEXT_PARSE_MAX_BYTES = 1_000_000
-
-
 def _try_json_loads(s: str) -> object | None:
     """Return ``json.loads(s)`` if *s* looks like a JSON object or array,
     otherwise return ``None``. Never raises. Used to expand kamui-code
@@ -79,10 +71,20 @@ def _try_json_loads(s: str) -> object | None:
     Conservative: only attempts parse when the trimmed string starts
     with ``{`` or ``[``. Bare strings, numbers, prose, etc. are never
     misinterpreted as embedded JSON.
+
+    Note on size: there is intentionally **no upper bound** on the
+    input size. MCP services may legitimately return multi-MB payloads
+    (streaming responses, inline base64 video, large batch results),
+    and silently returning ``None`` for an oversized but valid JSON
+    blob would cause the response to fall back to a string at the
+    caller and break the lazy-v2.13 contract that ``result`` is
+    structured. ``json.loads`` itself is fast (O(n)) and capable of
+    handling many MB without trouble. If runaway payload sizes ever
+    become a concern, the right place to enforce a limit is at the
+    network ingress (worker request body cap) or the DB (column size
+    check), not in the middle of a parser.
     """
     if not isinstance(s, str):
-        return None
-    if len(s) > _TEXT_PARSE_MAX_BYTES:
         return None
     t = s.strip()
     if not t or t[0] not in ("{", "["):

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_dashboard_smoke.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_dashboard_smoke.py
@@ -413,6 +413,33 @@ class TestJobDetailUrlSurfacing(unittest.TestCase):
             "JSON string, once from the parsed object). See Issue #73.",
         )
 
+    def test_dashboard_js_skip_guard_handles_text_parsed_null(self):
+        """`text_parsed: null` is NOT a structured form of `text` —
+        if a future client (or a malformed server) sends it, we must
+        still walk `text` so the URL is not silently lost. Codex
+        re-review #7 raised this as a defensive hardening item.
+
+        Pin the implementation by requiring the guard to test for
+        non-null and object type, not just `hasOwnProperty`."""
+        js = self._read("dashboard.js")
+        # Two complementary checks: explicit null exclusion and
+        # explicit object type assertion. Either alone would be
+        # easy to lose in a refactor; together they're hard to
+        # delete by accident.
+        self.assertIn(
+            "tp !== null", js,
+            "extractUrls's text_parsed skip guard must explicitly "
+            "exclude `null` so a `text_parsed: null` entry does not "
+            "cause `text` (which still carries the JSON string) to be "
+            "skipped, hiding URLs. Codex re-review #7.",
+        )
+        self.assertIn(
+            'typeof tp === "object"', js,
+            "extractUrls's text_parsed skip guard must require object "
+            "type so non-object scalars (e.g. `text_parsed: 42`) do "
+            "not trigger the skip path. Codex re-review #7.",
+        )
+
     def test_dashboard_js_detects_local_paths(self):
         """kamui-code results carry `local_files` with Windows or
         POSIX absolute paths. The walker exposes those as a separate

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_dashboard_smoke.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_dashboard_smoke.py
@@ -361,25 +361,33 @@ class TestJobDetailUrlSurfacing(unittest.TestCase):
         self.assertIn("Inputs (URLs in submit args)", js)
         self.assertIn("Outputs (URLs in result)", js)
 
-    def test_dashboard_js_handles_kamui_double_encoded_result(self):
+    def test_dashboard_js_no_longer_double_parses_kamui_text(self):
         """kamui-code MCP wraps the actual result payload as a JSON
-        string inside `remote_result.content[].text`. The walker has to
-        try-parse string nodes that begin with `{` or `[`, otherwise
-        the output URL (`images[].url` / `video.url`) is invisible to
-        the user — which is exactly the failure mode the lazy-v2.12.0
-        feature is designed to prevent. Sample shape from real jobs:
+        string inside `remote_result.content[].text`. As of Issue #73
+        (lazy-v2.13+) the **worker** annotates those entries with
+        `text_parsed`, so dashboard.js does not (and should not) carry
+        the in-browser `JSON.parse` fallback that earlier versions had.
 
-            "remote_result": {
-              "content": [
-                {"type": "text",
-                 "text": "{\\"video\\":{\\"url\\":\\"https://...\\"}}"}
-              ]
-            }
-        """
+        The actual parsing behavior is pinned by
+        `test_worker_normalize.py::TestNormalizeResultPayload::test_kamui_double_json_*`.
+        Here we just guard against accidental re-introduction of the
+        client-side parser: the obsolete `(parsed text)` path label
+        and the `JSON.parse(trimmed)` call must NOT come back."""
         js = self._read("dashboard.js")
-        # The walker labels embedded JSON paths with "(parsed text)".
-        # Future-proofing: if the label changes, this test catches it.
-        self.assertIn("(parsed text)", js)
+        self.assertNotIn(
+            "(parsed text)", js,
+            "Found '(parsed text)' label — the client-side double-JSON "
+            "parser was reintroduced. The worker now ships text_parsed.",
+        )
+        # The earlier dashboard literally had `JSON.parse(trimmed)`
+        # inside extractUrls. If it comes back, the client and the
+        # worker will both try to expand the same field, leading to
+        # confusing duplicate paths.
+        self.assertNotRegex(
+            js, r"JSON\.parse\(\s*trimmed\s*\)",
+            "extractUrls must not call JSON.parse on string nodes; the "
+            "worker already provides text_parsed (Issue #73).",
+        )
 
     def test_dashboard_js_detects_local_paths(self):
         """kamui-code results carry `local_files` with Windows or

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_dashboard_smoke.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_dashboard_smoke.py
@@ -389,6 +389,30 @@ class TestJobDetailUrlSurfacing(unittest.TestCase):
             "worker already provides text_parsed (Issue #73).",
         )
 
+    def test_dashboard_js_skips_text_when_text_parsed_is_present(self):
+        """When the worker ships `text_parsed` alongside `text` (the
+        canonical lazy-v2.13+ kamui-code shape), the walker must skip
+        the raw `text` field. Otherwise the prose-URL fallback would
+        re-extract the same URLs from the JSON-as-string in `text`,
+        producing duplicate entries that the dedup helper would then
+        have to collapse with confusing path labels.
+
+        We pin this by looking for the `text_parsed` skip guard in
+        `extractUrls`. If a future refactor removes the guard, this
+        test fails with an actionable message pointing at this
+        scenario."""
+        js = self._read("dashboard.js")
+        # The skip is gated on `hasOwnProperty("text_parsed")` so look
+        # for that string near the walker. Tightening the regex would
+        # make the test brittle — this is intentionally loose.
+        self.assertIn(
+            'hasOwnProperty.call(node, "text_parsed")', js,
+            "extractUrls must skip the raw `text` field when its "
+            "sibling `text_parsed` is present, otherwise URLs will "
+            "be extracted twice (once from prose-fallback over the "
+            "JSON string, once from the parsed object). See Issue #73.",
+        )
+
     def test_dashboard_js_detects_local_paths(self):
         """kamui-code results carry `local_files` with Windows or
         POSIX absolute paths. The walker exposes those as a separate

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_worker_normalize.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_worker_normalize.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+"""Tests for ``worker._normalize_result_payload`` and friends (Issue #73).
+
+The worker normalizes the ``result`` and ``args`` columns before
+serving them on ``/api/jobs/<id>`` so that:
+
+1. The DB-stored JSON string is returned as a parsed object, matching
+   how ``args`` was already handled.
+2. kamui-code MCP's ``remote_result.content[].text`` (which is *also*
+   a JSON-encoded string) is annotated with a sibling ``text_parsed``
+   field carrying the parsed value. This removes the need for the
+   dashboard (or any other client) to re-parse it.
+
+These tests pin both behaviors plus the failure modes the helper has
+to tolerate without raising: non-JSON ``result`` strings, missing
+``content`` array, non-dict items in ``content``, oversized payloads,
+and pre-parsed (already-dict) inputs.
+"""
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from job_queue.worker import (  # noqa: E402
+    _annotate_content_text,
+    _normalize_args_payload,
+    _normalize_result_payload,
+    _try_json_loads,
+)
+
+
+# ---------------------------------------------------------------------------
+# _try_json_loads
+# ---------------------------------------------------------------------------
+
+
+class TestTryJsonLoads(unittest.TestCase):
+    """The low-level helper that decides whether a string looks like
+    JSON and parses it without raising. Used by both the result and
+    args normalizers, so its conservatism matters."""
+
+    def test_parses_object_string(self):
+        self.assertEqual(_try_json_loads('{"a": 1}'), {"a": 1})
+
+    def test_parses_array_string(self):
+        self.assertEqual(_try_json_loads('[1, 2, 3]'), [1, 2, 3])
+
+    def test_returns_none_for_non_string(self):
+        self.assertIsNone(_try_json_loads(None))
+        self.assertIsNone(_try_json_loads(42))
+        self.assertIsNone(_try_json_loads({"a": 1}))
+
+    def test_returns_none_for_prose(self):
+        """Bare prose must not be misinterpreted as JSON. Notably,
+        plain strings, words, numbers as text, etc. should be left
+        alone — even if `json.loads` would parse them."""
+        self.assertIsNone(_try_json_loads("hello"))
+        self.assertIsNone(_try_json_loads("42"))
+        self.assertIsNone(_try_json_loads("true"))
+        self.assertIsNone(_try_json_loads('"a string"'))
+
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(_try_json_loads(""))
+        self.assertIsNone(_try_json_loads("   "))
+
+    def test_returns_none_for_malformed_json(self):
+        self.assertIsNone(_try_json_loads("{unclosed"))
+        self.assertIsNone(_try_json_loads("{ 'single-quoted': 1 }"))
+
+    def test_tolerates_leading_whitespace(self):
+        self.assertEqual(_try_json_loads("  \n {\"a\": 1}\n"), {"a": 1})
+
+    def test_returns_none_for_oversized_string(self):
+        """Above ~1 MB we refuse to attempt parsing. The exact threshold
+        is implementation-defined; the test just pins that some bound
+        exists so a runaway 50 MB result blob does not crater the
+        worker's response time."""
+        big = "{" + ("a" * 2_000_000) + "}"
+        self.assertIsNone(_try_json_loads(big))
+
+
+# ---------------------------------------------------------------------------
+# _annotate_content_text
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotateContentText(unittest.TestCase):
+    """Single-level expansion of ``content[].text`` into ``text_parsed``,
+    operating in place on the list."""
+
+    def test_annotates_json_text(self):
+        content = [
+            {"type": "text", "text": '{"images": [{"url": "https://x/y.png"}]}'},
+        ]
+        _annotate_content_text(content)
+        self.assertEqual(
+            content[0]["text_parsed"],
+            {"images": [{"url": "https://x/y.png"}]},
+        )
+        # Original `text` is preserved untouched.
+        self.assertEqual(
+            content[0]["text"],
+            '{"images": [{"url": "https://x/y.png"}]}',
+        )
+
+    def test_skips_non_json_text(self):
+        content = [{"type": "text", "text": "just a status message"}]
+        _annotate_content_text(content)
+        self.assertNotIn("text_parsed", content[0])
+
+    def test_skips_non_dict_items(self):
+        """A defensive guard for ``content`` arrays that contain
+        unexpected primitives. We must not raise."""
+        content = ["a string", 42, None, {"text": '{"x": 1}'}]
+        _annotate_content_text(content)
+        self.assertEqual(content[3]["text_parsed"], {"x": 1})
+        # The non-dict entries are still in place, unmodified.
+        self.assertEqual(content[0], "a string")
+        self.assertEqual(content[1], 42)
+        self.assertIsNone(content[2])
+
+    def test_skips_missing_text_field(self):
+        content = [{"type": "image"}]  # no `text` at all
+        _annotate_content_text(content)
+        self.assertNotIn("text_parsed", content[0])
+
+    def test_skips_non_string_text(self):
+        content = [{"type": "text", "text": 42}]
+        _annotate_content_text(content)
+        self.assertNotIn("text_parsed", content[0])
+
+    def test_non_list_input_is_noop(self):
+        # Just must not raise.
+        _annotate_content_text(None)  # type: ignore[arg-type]
+        _annotate_content_text("not a list")  # type: ignore[arg-type]
+        _annotate_content_text({"not": "a list"})  # type: ignore[arg-type]
+
+    def test_only_single_level_expansion(self):
+        """If ``text_parsed`` itself happens to contain another
+        ``content[].text`` shape, we do NOT recurse. Bounded
+        normalization keeps the helper predictable."""
+        inner_text = '{"images": [{"url": "https://x/y.png"}]}'
+        outer_text = (
+            '{"remote_result": {"content": [{"type": "text", "text": '
+            + json.dumps(inner_text) + "}]}}"
+        )
+        content = [{"type": "text", "text": outer_text}]
+        _annotate_content_text(content)
+        # Outer level is parsed.
+        outer_parsed = content[0]["text_parsed"]
+        self.assertIsInstance(outer_parsed, dict)
+        # Inner `content[].text` is NOT auto-expanded here; only the
+        # full normalizer (`_normalize_result_payload`) walks one
+        # remote_result.content layer below the top level.
+        inner_content = outer_parsed["remote_result"]["content"]
+        self.assertNotIn("text_parsed", inner_content[0])
+
+
+# ---------------------------------------------------------------------------
+# _normalize_result_payload
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeResultPayload(unittest.TestCase):
+    """The end-to-end result normalizer used by the /api/jobs/<id>
+    endpoint."""
+
+    def test_parses_json_string_into_object(self):
+        raw = '{"images": [{"url": "https://x/y.png"}]}'
+        out = _normalize_result_payload(raw)
+        self.assertEqual(out, {"images": [{"url": "https://x/y.png"}]})
+
+    def test_kamui_double_json_gets_text_parsed_annotation(self):
+        """Real kamui-code shape from production: the outer `result`
+        is JSON-string, and inside it `remote_result.content[].text`
+        is another JSON-encoded string carrying the actual URLs."""
+        inner = {"images": [{"url": "https://v3b.fal.media/files/a.png"}]}
+        outer = {
+            "remote_result": {
+                "content": [
+                    {"type": "text", "text": json.dumps(inner)},
+                ],
+            },
+            "local_files": ["C:\\Users\\u\\out.png"],
+            "download_errors": [],
+        }
+        raw = json.dumps(outer)
+        out = _normalize_result_payload(raw)
+
+        # Outer is a dict now
+        self.assertIsInstance(out, dict)
+        # Annotation present
+        item = out["remote_result"]["content"][0]
+        self.assertEqual(item["text_parsed"], inner)
+        # Original text is preserved
+        self.assertEqual(item["text"], json.dumps(inner))
+        # local_files survives the round-trip unchanged
+        self.assertEqual(out["local_files"], ["C:\\Users\\u\\out.png"])
+
+    def test_kamui_double_json_video_url(self):
+        """Same as above but with the video.url shape (t2v / r2v
+        completed jobs)."""
+        inner = {"video": {"url": "https://v3b.fal.media/files/v.mp4"},
+                 "seed": 12345}
+        outer = {
+            "remote_result": {
+                "content": [{"type": "text", "text": json.dumps(inner)}],
+            },
+        }
+        out = _normalize_result_payload(json.dumps(outer))
+        item = out["remote_result"]["content"][0]
+        self.assertEqual(item["text_parsed"], inner)
+
+    def test_invalid_json_returned_as_string(self):
+        """An executor that stored unstructured text (e.g. an HTML
+        error page) must not break the response. The raw string is
+        returned and the client decides how to render it."""
+        raw = "<html><body>500 Internal Server Error</body></html>"
+        out = _normalize_result_payload(raw)
+        self.assertEqual(out, raw)
+
+    def test_none_passes_through(self):
+        self.assertIsNone(_normalize_result_payload(None))
+
+    def test_empty_string_passes_through(self):
+        self.assertEqual(_normalize_result_payload(""), "")
+
+    def test_already_parsed_dict_gets_annotated(self):
+        """If a caller pre-parses (or a future code path stores the
+        result as JSON in the DB), we still annotate
+        ``remote_result.content[].text``."""
+        inner = {"images": [{"url": "https://x/a.png"}]}
+        pre_parsed = {
+            "remote_result": {
+                "content": [{"type": "text", "text": json.dumps(inner)}],
+            },
+        }
+        out = _normalize_result_payload(pre_parsed)
+        self.assertEqual(
+            out["remote_result"]["content"][0]["text_parsed"], inner,
+        )
+
+    def test_missing_remote_result_is_fine(self):
+        """Results without the kamui-code shape (e.g. minimal
+        executor results) must pass through unmodified."""
+        raw = json.dumps({"local_files": ["C:\\out.png"], "ok": True})
+        out = _normalize_result_payload(raw)
+        self.assertEqual(out, {"local_files": ["C:\\out.png"], "ok": True})
+
+    def test_remote_result_without_content_is_fine(self):
+        raw = json.dumps({"remote_result": {"status": "completed"}})
+        out = _normalize_result_payload(raw)
+        # Untouched (no `content` array → no annotation work)
+        self.assertEqual(out, {"remote_result": {"status": "completed"}})
+
+    def test_content_text_that_is_not_json(self):
+        """An MCP server that returned plain prose in
+        ``content[].text`` should not get a ``text_parsed`` field."""
+        raw = json.dumps({
+            "remote_result": {
+                "content": [{"type": "text", "text": "Generation complete."}],
+            },
+        })
+        out = _normalize_result_payload(raw)
+        item = out["remote_result"]["content"][0]
+        self.assertEqual(item["text"], "Generation complete.")
+        self.assertNotIn("text_parsed", item)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_args_payload
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeArgsPayload(unittest.TestCase):
+    """Mirror of the result helper for the args column. Notably it
+    does NOT recurse into ``content[].text`` — submitted args have
+    never used that shape and we do not want surprise expansion of
+    prompts that happen to look like JSON."""
+
+    def test_parses_json_object_string(self):
+        raw = '{"prompt": "a cat", "size": "1024x1024"}'
+        out = _normalize_args_payload(raw)
+        self.assertEqual(out, {"prompt": "a cat", "size": "1024x1024"})
+
+    def test_invalid_json_returned_as_string(self):
+        raw = "this is not JSON"
+        self.assertEqual(_normalize_args_payload(raw), raw)
+
+    def test_none_passes_through(self):
+        self.assertIsNone(_normalize_args_payload(None))
+
+    def test_already_parsed_dict_returned_unchanged(self):
+        d = {"a": 1, "b": 2}
+        self.assertEqual(_normalize_args_payload(d), d)
+
+    def test_does_not_recurse_into_content_text(self):
+        """Even if (hypothetically) submitted args carried a
+        ``remote_result.content[].text`` shape with JSON-as-string,
+        the args normalizer must not expand it — args expansion would
+        change semantics for clients that compare the round-tripped
+        args against the submitted ones byte-for-byte."""
+        raw = json.dumps({
+            "remote_result": {
+                "content": [{"type": "text", "text": '{"x": 1}'}],
+            },
+        })
+        out = _normalize_args_payload(raw)
+        # Top-level parsed (consistent with the legacy behavior of
+        # `json.loads(job["args"])` in worker.py).
+        self.assertIsInstance(out, dict)
+        # But the embedded JSON-as-string stays a string.
+        self.assertEqual(
+            out["remote_result"]["content"][0]["text"], '{"x": 1}',
+        )
+        self.assertNotIn("text_parsed", out["remote_result"]["content"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_worker_normalize.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_worker_normalize.py
@@ -38,8 +38,12 @@ from job_queue.worker import (  # noqa: E402
 
 class TestTryJsonLoads(unittest.TestCase):
     """The low-level helper that decides whether a string looks like
-    JSON and parses it without raising. Used by both the result and
-    args normalizers, so its conservatism matters."""
+    JSON and parses it without raising. Used by the result normalizer
+    (and by ``_annotate_content_text``) to decide whether
+    ``content[].text`` looks like an embedded JSON payload worth
+    expanding into ``text_parsed``. The args normalizer intentionally
+    does **not** route through this helper — see Codex re-review #6
+    in PR #75 for why."""
 
     def test_parses_object_string(self):
         self.assertEqual(_try_json_loads('{"a": 1}'), {"a": 1})

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_worker_normalize.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_worker_normalize.py
@@ -303,6 +303,25 @@ class TestNormalizeArgsPayload(unittest.TestCase):
         d = {"a": 1, "b": 2}
         self.assertEqual(_normalize_args_payload(d), d)
 
+    def test_parses_scalar_json_for_legacy_compat(self):
+        """Legacy `json.loads(j["args"])` accepted scalar JSON values
+        (`"42"`, `"true"`, `"null"`, `"\\"x\\""`). The normalizer must
+        preserve that behavior — routing through a conservative
+        "looks like object/array" check would silently change the
+        return type for any consumer that submitted a bare JSON
+        scalar as args. Codex re-review #6."""
+        # Number scalar
+        self.assertEqual(_normalize_args_payload("42"), 42)
+        # Boolean scalar
+        self.assertEqual(_normalize_args_payload("true"), True)
+        # null scalar → Python None (distinct from "args was empty
+        # string", which still falls through as ""—see test_none_passes_through)
+        self.assertIsNone(_normalize_args_payload("null"))
+        # String scalar (JSON-encoded string → Python str)
+        self.assertEqual(_normalize_args_payload('"hello"'), "hello")
+        # Float
+        self.assertEqual(_normalize_args_payload("3.14"), 3.14)
+
     def test_does_not_recurse_into_content_text(self):
         """Even if (hypothetically) submitted args carried a
         ``remote_result.content[].text`` shape with JSON-as-string,

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_worker_normalize.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_worker_normalize.py
@@ -72,13 +72,20 @@ class TestTryJsonLoads(unittest.TestCase):
     def test_tolerates_leading_whitespace(self):
         self.assertEqual(_try_json_loads("  \n {\"a\": 1}\n"), {"a": 1})
 
-    def test_returns_none_for_oversized_string(self):
-        """Above ~1 MB we refuse to attempt parsing. The exact threshold
-        is implementation-defined; the test just pins that some bound
-        exists so a runaway 50 MB result blob does not crater the
-        worker's response time."""
-        big = "{" + ("a" * 2_000_000) + "}"
-        self.assertIsNone(_try_json_loads(big))
+    def test_parses_large_json_without_size_cap(self):
+        """There is intentionally NO upper size limit on JSON parsing.
+        MCP services that stream large responses or return inline
+        base64 (video, image batches) can legitimately deliver
+        multi-MB ``result`` payloads, and silently dropping back to a
+        string at this layer would break the lazy-v2.13 contract that
+        ``result`` is structured. This test pins that a several-MB
+        valid JSON object parses successfully."""
+        # Build a ~5 MB valid JSON object with a long string value.
+        large_value = "x" * 5_000_000
+        payload = '{"data": "' + large_value + '"}'
+        result = _try_json_loads(payload)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result, {"data": large_value})
 
 
 # ---------------------------------------------------------------------------

--- a/.claude/skills/mcp-async-skill/scripts/tests/test_worker_normalize.py
+++ b/.claude/skills/mcp-async-skill/scripts/tests/test_worker_normalize.py
@@ -183,7 +183,7 @@ class TestNormalizeResultPayload(unittest.TestCase):
         """Real kamui-code shape from production: the outer `result`
         is JSON-string, and inside it `remote_result.content[].text`
         is another JSON-encoded string carrying the actual URLs."""
-        inner = {"images": [{"url": "https://v3b.fal.media/files/a.png"}]}
+        inner = {"images": [{"url": "https://example.com/files/a.png"}]}
         outer = {
             "remote_result": {
                 "content": [
@@ -209,7 +209,7 @@ class TestNormalizeResultPayload(unittest.TestCase):
     def test_kamui_double_json_video_url(self):
         """Same as above but with the video.url shape (t2v / r2v
         completed jobs)."""
-        inner = {"video": {"url": "https://v3b.fal.media/files/v.mp4"},
+        inner = {"video": {"url": "https://example.com/files/v.mp4"},
                  "seed": 12345}
         outer = {
             "remote_result": {

--- a/.claude/skills/queue-dashboard/scripts/static/dashboard.js
+++ b/.claude/skills/queue-dashboard/scripts/static/dashboard.js
@@ -394,7 +394,18 @@ function extractUrls(root, opts) {
       return;
     }
     if (typeof node === "object") {
+      // When the worker (lazy-v2.13+) annotates a kamui-code content
+      // entry with `text_parsed`, the structured form supersedes the
+      // raw `text` string for URL extraction purposes. Skipping `text`
+      // here avoids duplicate Outputs entries (one from the structured
+      // walk, one from the prose-fallback regex over the JSON string)
+      // and keeps path labels meaningful. The original `text` is still
+      // visible in the Raw JSON section.
+      const skipText = Object.prototype.hasOwnProperty.call(node, "text_parsed")
+        && Object.prototype.hasOwnProperty.call(node, "text")
+        && typeof node.text === "string";
       for (const key of Object.keys(node)) {
+        if (skipText && key === "text") continue;
         const subpath = path ? path + "." + key : key;
         visit(node[key], subpath, depth + 1);
       }

--- a/.claude/skills/queue-dashboard/scripts/static/dashboard.js
+++ b/.claude/skills/queue-dashboard/scripts/static/dashboard.js
@@ -335,13 +335,16 @@ function looksLikeLocalPath(s) {
 // human-readable JSON path. Duplicate URLs at different paths are kept
 // (the path tells you which one is which).
 //
-// kamui-code MCP returns JSON where the *actual* result payload is a
-// JSON string embedded inside `remote_result.content[].text`. We
-// transparently parse such strings (if and only if they start with
-// `{` or `[` after trim and parse cleanly) and walk into them, marking
-// the path with `(parsed text)` so the user knows where the URL came
-// from. This is the difference between "wow this is great" and "where
-// is my output URL?" in practice.
+// kamui-code MCP wraps the real payload as a JSON-encoded string inside
+// `remote_result.content[].text`. As of Issue #73, the worker side
+// (lazy-v2.13+) annotates those entries with a sibling `text_parsed`
+// field carrying the parsed value, so the walker just naturally
+// recurses into it as an object — no in-browser JSON.parse needed.
+//
+// For older workers that don't ship `text_parsed`, the URL stays
+// buried inside the string. The user-visible symptom is "Outputs
+// section empty even though the job completed"; the version
+// handshake (PR #62) already warns the user to restart the worker.
 //
 // Maximum depth and node count are bounded to keep huge result blobs
 // from freezing the modal.
@@ -362,18 +365,6 @@ function extractUrls(root, opts) {
       if (looksLikeLocalPath(node)) {
         out.push({ path, value: node, kind: classifyLocalPath(node), type: "local" });
         return;
-      }
-      // Embedded JSON (kamui-code wraps the real payload as a JSON
-      // string inside `content[].text`). Parse it transparently.
-      const trimmed = node.trim();
-      if (trimmed.length > 1 &&
-          (trimmed[0] === "{" || trimmed[0] === "[")) {
-        let parsed;
-        try { parsed = JSON.parse(trimmed); } catch { parsed = undefined; }
-        if (parsed !== undefined) {
-          visit(parsed, path + " (parsed text)", depth + 1);
-          return;
-        }
       }
       // Fallback: prose containing URLs (e.g. an error message that
       // mentions one). Only extract if the string is moderately long
@@ -602,12 +593,13 @@ async function showJobDetail(jobId) {
     return;
   }
 
-  // Parse result: API may return it either as already-parsed JSON or as
-  // a raw string (older worker versions). Be defensive.
-  let resultObj = data.result;
-  if (typeof resultObj === "string") {
-    try { resultObj = JSON.parse(resultObj); } catch { /* leave as string */ }
-  }
+  // As of lazy-v2.13 (Issue #73) the worker returns `result` as a
+  // fully-parsed object with kamui-code's content[].text annotated as
+  // `text_parsed`. Older workers (≤ lazy-v2.12) return `result` as a
+  // raw string and the URL extraction will be limited to whatever the
+  // walker can find on the surface — the version-handshake warning in
+  // the header tells the user to restart the worker in that case.
+  const resultObj = data.result;
   const argsObj = data.args;
 
   const inputUrls = dedupeUrlEntries(

--- a/.claude/skills/queue-dashboard/scripts/static/dashboard.js
+++ b/.claude/skills/queue-dashboard/scripts/static/dashboard.js
@@ -395,13 +395,21 @@ function extractUrls(root, opts) {
     }
     if (typeof node === "object") {
       // When the worker (lazy-v2.13+) annotates a kamui-code content
-      // entry with `text_parsed`, the structured form supersedes the
-      // raw `text` string for URL extraction purposes. Skipping `text`
-      // here avoids duplicate Outputs entries (one from the structured
-      // walk, one from the prose-fallback regex over the JSON string)
-      // and keeps path labels meaningful. The original `text` is still
-      // visible in the Raw JSON section.
-      const skipText = Object.prototype.hasOwnProperty.call(node, "text_parsed")
+      // entry with a *non-null object/array* `text_parsed`, the
+      // structured form supersedes the raw `text` string for URL
+      // extraction. Skipping `text` here avoids duplicate Outputs
+      // entries (one from the structured walk, one from the prose-
+      // fallback regex over the JSON string).
+      //
+      // Defensive about edge cases the worker shouldn't produce but a
+      // future client might: `text_parsed: null` or `text_parsed: 42`
+      // are NOT structured forms of `text`, so we keep walking `text`
+      // in those cases — otherwise the URL would silently disappear.
+      const tp = node.text_parsed;
+      const skipText =
+        Object.prototype.hasOwnProperty.call(node, "text_parsed")
+        && tp !== null
+        && typeof tp === "object"
         && Object.prototype.hasOwnProperty.call(node, "text")
         && typeof node.text === "string";
       for (const key of Object.keys(node)) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [Unreleased] — targeting lazy-v2.13.0
+
+### Changed (BREAKING)
+- **`GET /api/jobs/<id>` の `result` フィールドが string → object になります** ([#73](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/issues/73)): これまで `result` は DB に格納された JSON 文字列をそのまま返していました (`args` だけは parse 済み object として返る、という非対称な API)。lazy-v2.13.0 から `result` も object として返り、kamui-code MCP の `remote_result.content[].text` (こちらもさらに JSON 文字列としてエンコードされている) には parse 済みの `text_parsed` フィールドを併記します。
+  - **影響**: `result` を文字列として参照 (`jq -r '.result'` 等) していた外部スクリプトは動作が変わります。本リポジトリ内部 (Python クライアント / CLI / dashboard) の影響箇所は調査・修正済み。
+  - **新形状の例**:
+    ```jsonc
+    {
+      "result": {                                  // ← object (was string)
+        "remote_result": {
+          "content": [{
+            "type": "text",
+            "text": "{\"video\":{\"url\":\"https://...\"}}",  // 原文を保持
+            "text_parsed": {                                  // ← 新規
+              "video": {"url": "https://..."}
+            }
+          }]
+        },
+        "local_files": ["C:\\Users\\..\\out.mp4"],
+        "download_errors": []
+      }
+    }
+    ```
+  - **`text_parsed` のルール**:
+    - `text` が `{` または `[` で始まる string で、JSON parse 可能なら付与
+    - 不正 JSON / prose / 数値などは付与しない (= フィールド非存在)
+    - **ネスト展開は 1 段のみ**: `text_parsed` 内にさらに JSON-as-string が含まれていても再展開しない
+    - 1 MB を超える `text` は parse 試行しない (応答時間ガード)
+  - **`/api/jobs/<id>` の `args` の挙動は変えていません**: 引き続き parse 済み object として返ります。`args` 内の `content[].text` には `text_parsed` は **付与しません** (= submitted args の round-trip 一致を保つため)。
+
+### Added
+- **worker.py に `_normalize_result_payload` / `_normalize_args_payload` / `_annotate_content_text` / `_try_json_loads` を追加** ([#73](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/issues/73)): kamui-code MCP のレスポンス形状の理解を worker 単独の責務に集約。dashboard やその他のクライアントが二重 JSON ロジックを実装しなくて済みます。
+- 新規テスト: `test_worker_normalize.py` (30 tests) — `_try_json_loads` / `_annotate_content_text` / `_normalize_result_payload` / `_normalize_args_payload` の正常系・異常系を pin
+
+### Changed
+- **dashboard.js: `extractUrls` から二重 JSON parse 分岐を削除**: lazy-v2.13.0 worker が `text_parsed` を併記するようになったので、JavaScript 側で `JSON.parse(trimmed)` を呼ぶ必要がなくなりました。`(parsed text)` という path ラベルも消えます。これにより dashboard.js の純粋ロジックが縮小し、kamui-code 固有の応答形状に依存しないシンプルな再帰 walker になります。
+- **dashboard.js: `showJobDetail` の `typeof === "string"` fallback も削除**: `result` は常に object 前提。万一旧 worker (≤ lazy-v2.12) と組み合わせて使われた場合、URL 表面化は劣化しますが ([PR #62](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/pull/65) の version handshake が「worker を再起動してください」と警告を出します)、raw JSON は引き続き `<details>` 内で参照できます。
+- **`test_dashboard_smoke.py::TestJobDetailUrlSurfacing::test_dashboard_js_no_longer_double_parses_kamui_text`**: 旧 `(parsed text)` ラベル要求テストを「`JSON.parse(trimmed)` が dashboard.js に **存在しない**」逆向きの assertion に書き換え、再混入を防止。
+
+### Compatibility
+- **lazy-v2.12.x 以前の worker と lazy-v2.13.0 dashboard の組み合わせ**: 旧 worker は `result` を string、`text_parsed` なしで返します。新 dashboard は `result` が object でないと extractUrls が深く展開できないため、Outputs セクションが空 (もしくは prose URL 抽出だけ) になる可能性があります。raw JSON は引き続き表示可能。**worker と dashboard を同時にアップデートすることを推奨**します (元々 lazy-v2.11+ の worker version handshake が同じ意図で警告を出しています)。
+- **lazy-v2.13.0 worker と lazy-v2.12.x 以前の dashboard の組み合わせ**: 旧 dashboard が `result` を string として `JSON.parse` する fallback ロジックを持っているため、object として返っても問題なく動作します (typeof チェックでスキップされる)。`text_parsed` フィールドは無視されますが、旧 dashboard 自身が二重 JSON 分岐を持つので URL は引き続き見えます。
+- **外部スクリプト / 自前 CLI で `result` を文字列として `jq` 等で扱っているケース**: 動作変化があります。新形状を `jq -r '.result | tojson'` のように再シリアライズすれば従来通り扱えます。
+
 ## [lazy-v2.12.0](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/releases/tag/lazy-v2.12.0) (2026-05-11)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,12 @@
     - 不正 JSON / prose / 数値などは付与しない (= フィールド非存在)
     - **ネスト展開は 1 段のみ**: `text_parsed` の中にさらに JSON-as-string が含まれていても再展開しない (worker の責務範囲を有限に保つため)
     - **サイズ上限なし**: streaming response や inline base64 のように multi-MB の payload を返すエンドポイントを正しく扱うため。`json.loads` 自体は数 MB で十数 ms オーダーなので応答時間に問題は出ない
-  - **`/api/jobs/<id>` の `args` の挙動は変えていません**: 引き続き parse 済み object として返ります (旧 lazy-v2.12 と同じ)。`args` 内の `content[].text` には `text_parsed` は **付与しません** — submitted args が round-trip で byte 一致することを期待する consumer (テスト・監査ログ等) を壊さないため。
+  - **`/api/jobs/<id>` の `args` の挙動は実質互換**: 旧 `json.loads(j["args"])` インライン処理を `_normalize_args_payload` ヘルパ経由に変更しましたが、内部実装は **同じく `json.loads` を直接呼ぶ** 形を維持。これにより legacy code が parse できていた **scalar JSON** (`"42"`, `"true"`, `"null"`, `"\"x\""`) も引き続き parse されて返ります。`args` 内の `content[].text` には `text_parsed` は **付与しません** — submitted args が round-trip で byte 一致することを期待する consumer (テスト・監査ログ等) を壊さないため。
 
 ### Added
 - **worker.py に `_normalize_result_payload` / `_normalize_args_payload` / `_annotate_content_text` / `_try_json_loads` を追加** ([#73](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/issues/73)): kamui-code MCP のレスポンス形状の理解を worker 単独の責務に集約。dashboard やその他のクライアントが二重 JSON ロジックを実装しなくて済みます。
-- 新規テスト: `test_worker_normalize.py` (30 tests) — `_try_json_loads` / `_annotate_content_text` / `_normalize_result_payload` / `_normalize_args_payload` の正常系・異常系を pin。サイズ上限なしを `test_parses_large_json_without_size_cap` (5 MB の valid JSON object) で明示。
-- 新規 smoke test: `test_dashboard_js_skips_text_when_text_parsed_is_present` — walker が text_parsed の sibling text をスキップすることを pin
+- 新規テスト: `test_worker_normalize.py` (31 tests) — `_try_json_loads` / `_annotate_content_text` / `_normalize_result_payload` / `_normalize_args_payload` の正常系・異常系を pin。サイズ上限なしを `test_parses_large_json_without_size_cap` (5 MB の valid JSON object) で明示。args の scalar JSON (`"42"`, `"true"`, `"null"` 等) 互換維持を `test_parses_scalar_json_for_legacy_compat` で pin。
+- 新規 smoke test (2 件): `test_dashboard_js_skips_text_when_text_parsed_is_present` — walker が text_parsed の sibling text をスキップすることを pin。`test_dashboard_js_skip_guard_handles_text_parsed_null` — text_parsed が null や非 object scalar の場合は skip しないことを pin (text に URL が埋まったままのケースを想定)。
 - **テスト fixture 中の URL は `https://example.com/...` を使用**: `test_worker_normalize.py` の二重 JSON テストでは「shape を pin したい」のが目的で、URL のドメイン値そのものは情報を持たない。下流 MCP サービスの実ドメインを test fixture に焼き付けない方針 (Issue [#76](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/issues/76))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased] — targeting lazy-v2.13.0
 
 ### Changed (BREAKING)
-- **`GET /api/jobs/<id>` の `result` フィールドが string → object になります** ([#73](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/issues/73)): これまで `result` は DB に格納された JSON 文字列をそのまま返していました (`args` だけは parse 済み object として返る、という非対称な API)。lazy-v2.13.0 から `result` も object として返り、kamui-code MCP の `remote_result.content[].text` (こちらもさらに JSON 文字列としてエンコードされている) には parse 済みの `text_parsed` フィールドを併記します。
+- **`GET /api/jobs/<id>` の `result` フィールドが、有効な JSON object/array なら parse 済み object として返るようになります** ([#73](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/issues/73)): これまで `result` は DB に格納された JSON 文字列をそのまま返していました (`args` だけは parse 済み object として返る、という非対称な API)。lazy-v2.13.0 から `result` も parse 済み object として返り、加えて kamui-code MCP の `remote_result.content[].text` (こちらもさらに JSON 文字列としてエンコードされている) には parse 済みの `text_parsed` フィールドを併記します。
   - **影響**: `result` を文字列として参照 (`jq -r '.result'` 等) していた外部スクリプトは動作が変わります。本リポジトリ内部 (Python クライアント / CLI / dashboard) の影響箇所は調査・修正済み。
   - **新形状の例**:
     ```jsonc
@@ -23,21 +23,28 @@
       }
     }
     ```
-  - **`text_parsed` のルール**:
-    - `text` が `{` または `[` で始まる string で、JSON parse 可能なら付与
+  - **`result` の正確な変換ルール**:
+    - **valid な JSON object / array string**: parse 済み object として返る (= 上の例)
+    - **`null` / `""` (空文字列)**: そのまま (None / 空文字) で返る — 「ジョブ未完了」「結果なし」を保持
+    - **不正 JSON 文字列 / prose / scalar JSON (`"42"`, `"true"` 等)**: string のまま fallback で返る — kamui-code 以外の executor が unstructured text を保存していた場合の互換のため
+    - **既に parse 済みの dict が DB に入っていた場合 (将来の DB 層変更への備え)**: そのまま object として通り、`remote_result.content[].text` のアノテーションも適用される
+  - **`text_parsed` の付与ルール**:
+    - `text` が `{` または `[` で始まる string で、JSON として parse 可能なら付与
     - 不正 JSON / prose / 数値などは付与しない (= フィールド非存在)
-    - **ネスト展開は 1 段のみ**: `text_parsed` 内にさらに JSON-as-string が含まれていても再展開しない
-    - 1 MB を超える `text` は parse 試行しない (応答時間ガード)
-  - **`/api/jobs/<id>` の `args` の挙動は変えていません**: 引き続き parse 済み object として返ります。`args` 内の `content[].text` には `text_parsed` は **付与しません** (= submitted args の round-trip 一致を保つため)。
+    - **ネスト展開は 1 段のみ**: `text_parsed` の中にさらに JSON-as-string が含まれていても再展開しない (worker の責務範囲を有限に保つため)
+    - **サイズ上限なし**: streaming response や inline base64 のように multi-MB の payload を返すエンドポイントを正しく扱うため。`json.loads` 自体は数 MB で十数 ms オーダーなので応答時間に問題は出ない
+  - **`/api/jobs/<id>` の `args` の挙動は変えていません**: 引き続き parse 済み object として返ります (旧 lazy-v2.12 と同じ)。`args` 内の `content[].text` には `text_parsed` は **付与しません** — submitted args が round-trip で byte 一致することを期待する consumer (テスト・監査ログ等) を壊さないため。
 
 ### Added
 - **worker.py に `_normalize_result_payload` / `_normalize_args_payload` / `_annotate_content_text` / `_try_json_loads` を追加** ([#73](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/issues/73)): kamui-code MCP のレスポンス形状の理解を worker 単独の責務に集約。dashboard やその他のクライアントが二重 JSON ロジックを実装しなくて済みます。
-- 新規テスト: `test_worker_normalize.py` (30 tests) — `_try_json_loads` / `_annotate_content_text` / `_normalize_result_payload` / `_normalize_args_payload` の正常系・異常系を pin
+- 新規テスト: `test_worker_normalize.py` (30 tests) — `_try_json_loads` / `_annotate_content_text` / `_normalize_result_payload` / `_normalize_args_payload` の正常系・異常系を pin。サイズ上限なしを `test_parses_large_json_without_size_cap` (5 MB の valid JSON object) で明示。
+- 新規 smoke test: `test_dashboard_js_skips_text_when_text_parsed_is_present` — walker が text_parsed の sibling text をスキップすることを pin
 
 ### Changed
 - **dashboard.js: `extractUrls` から二重 JSON parse 分岐を削除**: lazy-v2.13.0 worker が `text_parsed` を併記するようになったので、JavaScript 側で `JSON.parse(trimmed)` を呼ぶ必要がなくなりました。`(parsed text)` という path ラベルも消えます。これにより dashboard.js の純粋ロジックが縮小し、kamui-code 固有の応答形状に依存しないシンプルな再帰 walker になります。
 - **dashboard.js: `showJobDetail` の `typeof === "string"` fallback も削除**: `result` は常に object 前提。万一旧 worker (≤ lazy-v2.12) と組み合わせて使われた場合、URL 表面化は劣化しますが ([PR #62](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/pull/65) の version handshake が「worker を再起動してください」と警告を出します)、raw JSON は引き続き `<details>` 内で参照できます。
 - **`test_dashboard_smoke.py::TestJobDetailUrlSurfacing::test_dashboard_js_no_longer_double_parses_kamui_text`**: 旧 `(parsed text)` ラベル要求テストを「`JSON.parse(trimmed)` が dashboard.js に **存在しない**」逆向きの assertion に書き換え、再混入を防止。
+- **dashboard.js: `text_parsed` を持つ dict node では sibling の `text` を walker でスキップ**: worker 側で text_parsed が併記されるようになったので、walker が text (生 JSON 文字列) と text_parsed (parsed object) の両方から URL を抽出すると重複が発生する。sibling の text_parsed を検知したら text の visit を skip することで、dedup ヘルパに頼らず根本で重複を防止。新規 smoke test `test_dashboard_js_skips_text_when_text_parsed_is_present` で pin。
 
 ### Compatibility
 - **lazy-v2.12.x 以前の worker と lazy-v2.13.0 dashboard の組み合わせ**: 旧 worker は `result` を string、`text_parsed` なしで返します。新 dashboard は `result` が object でないと extractUrls が深く展開できないため、Outputs セクションが空 (もしくは prose URL 抽出だけ) になる可能性があります。raw JSON は引き続き表示可能。**worker と dashboard を同時にアップデートすることを推奨**します (元々 lazy-v2.11+ の worker version handshake が同じ意図で警告を出しています)。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - **worker.py に `_normalize_result_payload` / `_normalize_args_payload` / `_annotate_content_text` / `_try_json_loads` を追加** ([#73](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/issues/73)): kamui-code MCP のレスポンス形状の理解を worker 単独の責務に集約。dashboard やその他のクライアントが二重 JSON ロジックを実装しなくて済みます。
 - 新規テスト: `test_worker_normalize.py` (30 tests) — `_try_json_loads` / `_annotate_content_text` / `_normalize_result_payload` / `_normalize_args_payload` の正常系・異常系を pin。サイズ上限なしを `test_parses_large_json_without_size_cap` (5 MB の valid JSON object) で明示。
 - 新規 smoke test: `test_dashboard_js_skips_text_when_text_parsed_is_present` — walker が text_parsed の sibling text をスキップすることを pin
+- **テスト fixture 中の URL は `https://example.com/...` を使用**: `test_worker_normalize.py` の二重 JSON テストでは「shape を pin したい」のが目的で、URL のドメイン値そのものは情報を持たない。下流 MCP サービスの実ドメインを test fixture に焼き付けない方針 (Issue [#76](https://github.com/Yumeno/LazyKamuiCodeSkillsCreator/issues/76))
 
 ### Changed
 - **dashboard.js: `extractUrls` から二重 JSON parse 分岐を削除**: lazy-v2.13.0 worker が `text_parsed` を併記するようになったので、JavaScript 側で `JSON.parse(trimmed)` を呼ぶ必要がなくなりました。`(parsed text)` という path ラベルも消えます。これにより dashboard.js の純粋ロジックが縮小し、kamui-code 固有の応答形状に依存しないシンプルな再帰 walker になります。


### PR DESCRIPTION
Fixes #73

## Summary

kamui-code MCP のレスポンス形状 (`remote_result.content[].text` が二重 JSON エンコード) の理解を **dashboard.js から worker.py に移行** しました。`/api/jobs/<id>` は `result` を parsed object として返し、`content[].text` には parse 済みの `text_parsed` フィールドを併記します。

これにより:
- dashboard.js の二重 JSON parse 分岐が削除可能になり、純粋な「再帰 walker + URL/path 判定」だけになる
- 将来のクライアント (CLI、別 UI、自前スクリプト) も同じ正規化済み形状を見られる
- 挙動を **Python で pytest pin** できる (lazy-v2.12.0 では JS のためテスト戦略が苦しかった)
- `args` と `result` の API 非対称が解消 (どちらも parsed object として返る)

## API 変更 (BREAKING)

| | Before (≤ lazy-v2.12) | After (lazy-v2.13+) |
|---|---|---|
| `result` の型 | string (JSON 文字列) | object (parsed) |
| `content[].text` | string (二重 JSON) | string (原文保持) + `text_parsed` (parsed) **新規併記** |
| `args` の型 | object (parsed) | object (parsed) — 不変 |

新形状の例:

```jsonc
{
  "result": {
    "remote_result": {
      "content": [{
        "type": "text",
        "text": "{\"video\":{\"url\":\"https://...\"}}",
        "text_parsed": {                                  // ← 新規
          "video": {"url": "https://..."}
        }
      }]
    },
    "local_files": ["C:\\Users\\..\\out.mp4"],
    "download_errors": []
  }
}
```

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `worker.py` | `_try_json_loads` / `_annotate_content_text` / `_normalize_result_payload` / `_normalize_args_payload` 新設、`/api/jobs/<id>` レスポンス組立を helper 経由に、`/api/jobs` (list) の args も同 helper 経由に統一 |
| `tests/test_worker_normalize.py` | 新規 30 tests (_try_json_loads / _annotate_content_text / _normalize_result_payload / _normalize_args_payload の正常系・異常系を pin) |
| `tests/test_dashboard_smoke.py` | `test_dashboard_js_handles_kamui_double_encoded_result` を逆向き assertion (`test_dashboard_js_no_longer_double_parses_kamui_text`) に書き換え、`(parsed text)` ラベルや `JSON.parse(trimmed)` の再混入を防止 |
| `dashboard.js` | extractUrls の二重 JSON 分岐 + showJobDetail の typeof==="string" fallback を削除 (worker 側で処理される) |
| `CHANGELOG.md` | `[Unreleased] — targeting lazy-v2.13.0` セクションを新設、Changed (BREAKING) と Compatibility を詳記 |

## テスト

- 新規 `test_worker_normalize.py`: **30 件 pass**
  - _try_json_loads: 8 件 (object / array / non-string / prose / empty / malformed / whitespace / oversized)
  - _annotate_content_text: 7 件 (annotation / non-JSON skip / non-dict tolerance / missing key / non-string text / non-list input / **single-level only**)
  - _normalize_result_payload: 10 件 (parse / kamui double-JSON for images / kamui double-JSON for video / invalid JSON / None / empty / pre-parsed dict / missing remote_result / missing content / non-JSON content[].text)
  - _normalize_args_payload: 5 件 (parse / invalid / None / pre-parsed / **does not recurse into content[].text** ← intentional asymmetry)
- 全 suite: **453 passed** (lazy-v2.12.0 の 423 から +30)

## 後方互換 (skew matrix)

| 組み合わせ | 動作 |
|---|---|
| 新 worker + 新 dashboard | ✅ canonical path |
| 新 worker + 旧 dashboard (≤ lazy-v2.12) | ✅ 旧 dashboard の `typeof === "string"` fallback で問題なし、text_parsed は無視されるが旧 dashboard 自身が JS 側で二重 JSON parse するので URL は見える |
| **旧 worker (≤ lazy-v2.12) + 新 dashboard** | ⚠️ Outputs セクションが空になる (URL が surface に出ないため)。lazy-v2.11+ worker version handshake が「shutdown して再起動を」と警告を出すので、これに従ってもらう前提 |
| 外部スクリプト (`jq -r '.result'`) | ⚠️ 動作変化あり。`jq -r '.result | tojson'` で再シリアライズすれば従来通り |

## 関連

- Closes #73
- Issue #74 (PR #72 で対応済): dashboard URL surfacing — 本 PR は #74 の「二重 JSON 展開を将来 worker 側に移す候補」と書いた部分の実装
- Issue #71 (subagent docs): 別軸、独立

## Test plan

- [x] `pytest .claude/skills/mcp-async-skill/scripts/tests/ -q` → 453 passed
- [x] 旧 worker と新 dashboard の skew は warning で誘導する設計を CHANGELOG に明記
- [ ] **マージ前にローカルで dashboard 起動して目視確認** (推奨、kamuicode_seedancetest2 の実 DB で完了ジョブをクリックして URL が見えること)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
